### PR TITLE
Add missing base classes for labels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,10 @@ module ApplicationHelper
     'active' if name == controller_name
   end
 
+  def project_type_class(names)
+    [names, ('selected' if names.include?(action_name))]
+  end
+
   def body_css_classes
     "#{controller_path.gsub('/', ' ')} #{action_name}"
   end

--- a/app/views/dashboard/index.haml
+++ b/app/views/dashboard/index.haml
@@ -1,12 +1,12 @@
 %h2 Projects
 %ul.projects-types
-  %li{class: [["active", "index"].include?(controller.action_name) && "selected"]}
+  %li{ class: ["active", ("selected" if ["active", "index"].include?(controller.action_name))] }
     =link_to active_dashboard_index_path do
       Active
-  %li{class: [controller.action_name == "potential" && "selected"]}
+  %li{ class: ["potential", ("selected" if controller.action_name == "potential")] }
     = link_to potential_dashboard_index_path do
       Potential
-  %li{class: [controller.action_name == "archived" && "selected"]}
+  %li{ class: ["archived", ("selected" if controller.action_name == "archived")] }
     = link_to archived_dashboard_index_path do
       Archived
 = react_component('projects', { projects: ActiveModel::ArraySerializer.new(projects, each_serializer: ProjectSerializer).as_json, users: ActiveModel::ArraySerializer.new(users, each_serializer: UserSerializer).as_json, memberships: memberships.as_json })

--- a/app/views/dashboard/index.haml
+++ b/app/views/dashboard/index.haml
@@ -1,12 +1,12 @@
 %h2 Projects
 %ul.projects-types
-  %li{ class: ["active", ("selected" if ["active", "index"].include?(controller.action_name))] }
-    =link_to active_dashboard_index_path do
+  %li{ class: project_type_class(["active", "index"]) }
+    = link_to active_dashboard_index_path do
       Active
-  %li{ class: ["potential", ("selected" if controller.action_name == "potential")] }
+  %li{ class: project_type_class("potential") }
     = link_to potential_dashboard_index_path do
       Potential
-  %li{ class: ["archived", ("selected" if controller.action_name == "archived")] }
+  %li{ class: project_type_class("archived") }
     = link_to archived_dashboard_index_path do
       Archived
 = react_component('projects', { projects: ActiveModel::ArraySerializer.new(projects, each_serializer: ProjectSerializer).as_json, users: ActiveModel::ArraySerializer.new(users, each_serializer: UserSerializer).as_json, memberships: memberships.as_json })


### PR DESCRIPTION
After the last fix, the base classes - `active`, `potential` and `archived` - were missing, which broke one of the specs and prevented a successful CI build.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-4