### PR TITLE
Fix display timeline

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -16,5 +16,5 @@
 :javascript
   var elTimeline = $(".timeline");
   var timeline = elTimeline.timeline(gon.events, gon.project);
-  elTimeline.scrollTo(elTimeline[0].scrollWidth, 0)
-  $('main-container').append(timeline);
+  elTimeline.scrollTo(elTimeline[0].scrollWidth, 0);
+  $('#main-container').append(timeline);

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -24,3 +24,9 @@
   .time-section
     .timeline
     .timeline-buttons
+
+:javascript
+  var elTimeline = $(".timeline");
+  var timeline = elTimeline.timeline(gon.events);
+  elTimeline.scrollTo(elTimeline[0].scrollWidth, 0);
+  $('#user').append(timeline);


### PR DESCRIPTION
Before the refactor, this was all initialized by Backbone. Currently we do not have any react in the user profile view, so the JS code is executed through `app/assets/javascripts/` or like this, locally. Future refactors should move the whole view and its functionalities to React.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-27