### PR TITLE
Fix capybara with react

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,15 +79,12 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara'
+  gem 'capybara-webkit'
   gem 'codeclimate-test-reporter', require: false
   gem 'database_cleaner'
-  gem 'phantomjs', require: 'phantomjs/poltergeist'
-  gem 'poltergeist'
   gem 'rack_session_access'
   gem 'rspec-rails'
   gem 'rspec-its'
-  gem 'selenium-webdriver'
   gem 'shoulda'
   gem 'timecop'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.7.1)
+      capybara (>= 2.3.0, < 2.6.0)
+      json
     carrierwave (0.10.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -127,10 +130,7 @@ GEM
       timers (>= 4.1.1)
     celluloid-supervision (0.20.5)
       timers (>= 4.1.1)
-    childprocess (0.5.8)
-      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
@@ -183,7 +183,6 @@ GEM
       i18n (~> 0.5)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
-    ffi (1.9.10)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     flip (1.0.1)
@@ -424,12 +423,6 @@ GEM
       omniauth (~> 1.0)
     orm_adapter (0.5.0)
     pg (0.18.4)
-    phantomjs (1.9.8.0)
-    poltergeist (1.8.1)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      multi_json (~> 1.0)
-      websocket-driver (>= 0.2.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -519,7 +512,6 @@ GEM
       rest-client (~> 1.8.0)
     ruby_parser (3.6.5)
       sexp_processor (~> 4.1)
-    rubyzip (1.1.7)
     safe_yaml (1.0.4)
     sass (3.4.19)
     sass-rails (5.0.4)
@@ -531,11 +523,6 @@ GEM
     searchlight (3.1.1)
       named (~> 1.0)
     selectize-rails (0.12.1)
-    selenium-webdriver (2.48.1)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     sexp_processor (4.5.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -602,10 +589,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.2)
-    websocket-driver (0.6.3)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
@@ -632,7 +615,7 @@ DEPENDENCIES
   capistrano
   capistrano-docker!
   capistrano-rvm
-  capybara
+  capybara-webkit
   carrierwave
   codeclimate-test-reporter
   coffee-rails
@@ -671,8 +654,6 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   pg
-  phantomjs
-  poltergeist
   pry
   pry-byebug
   pry-rails
@@ -690,7 +671,6 @@ DEPENDENCIES
   sass-rails
   searchlight
   selectize-rails
-  selenium-webdriver
   shoulda
   simple_form
   slack-notifier
@@ -704,4 +684,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,6 @@ require 'webmock/rspec'
 require 'sucker_punch/testing/inline'
 require 'capybara/rspec'
 require 'rack_session_access/capybara'
-require 'capybara/poltergeist'
-require 'phantomjs'
 require 'database_cleaner'
 
 
@@ -58,15 +56,6 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
-  # HACK to force asset compilation in a Rack request so it's ready for
-  # the Poltergeist request that otherwise times out.
-  config.before(:all) do
-    if self.respond_to? :visit
-      visit '/assets/application.css'
-      visit '/assets/application.js'
-    end
-  end
 end
 
 CarrierWave.configure do |config|
@@ -74,16 +63,4 @@ CarrierWave.configure do |config|
   config.enable_processing = false
 end
 
-Capybara.register_driver :poltergeist do |app|
-  options = {
-    phantomjs: Phantomjs.path,
-    js_errors: false,
-    timeout: 120,
-    debug: false,
-    phantomjs_options: ['--load-images=no', '--disk-cache=false'],
-    inspector: false
-  }
-  Capybara::Poltergeist::Driver.new(app, options)
-end
-
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :webkit


### PR DESCRIPTION
Turns out that PhantomJS/Poltergeist does not render any React components (even if you do things like wait_for_ajax and sleep(5000). Switching to capybara webkit solves the problem. Also, we had some redundant drivers in the Gemfile.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-14