### PR TITLE
Update hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
-Style/DotPosition:
-  EnforcedStyle: leading
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
+ruby:
+  config_file: .rubocop.yml
+javascript:
+  esnext: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
 Documentation:
   Enabled: false
 Metrics/LineLength:
-  Enabled: false
+  Max: 100
   Exclude:
     - 'config/**/*'
 Rails/TimeZone:
@@ -26,5 +26,5 @@ Style/StringLiterals:
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
   Enabled: true
-Style/IfUnlessModifier:
-  MaxLineLength: 100
+Metrics/ClassLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,28 @@
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'Rakefile'
+Documentation:
+  Enabled: false
+Metrics/LineLength:
+  Enabled: false
+  Exclude:
+    - 'config/**/*'
+Rails/TimeZone:
+  Enabled: false
+SignalException:
+  Enabled: false
+Style/PredicateName:
+  NamePrefix:
+    - is_
+    - have_
+  NamePrefixBlacklist:
+    - is_
+    - have_
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,5 @@ Style/StringLiterals:
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
   Enabled: true
+Style/IfUnlessModifier:
+  MaxLineLength: 100


### PR DESCRIPTION
we want to use ES6 syntax in our file so we need to enable `esnext` option in our config.

Moreover, it's good to have a local `.rubocop.yml` file in the project, so I've added it here - we can pimp the config in this PR - commits & comments are more than welcome:)