### PR TITLE
Fix to rotate ordering

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,6 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
   CountComments: false
-  Max: 10
+  Max: 15
 Style/DotPosition:
   EnforcedStyle: leading

--- a/app/repositories/scheduled_users_repository.rb
+++ b/app/repositories/scheduled_users_repository.rb
@@ -26,7 +26,7 @@ class ScheduledUsersRepository
         projects: { end_at: nil, internal: false },
         memberships: { ends_at: nil })
       .merge(Project.active.nonpotential.not_maintenance)
-      .order('COALESCE(memberships.ends_at, projects.end_at)')
+      .order('COALESCE(memberships.starts_at, projects.starts_at)')
   end
 
   def in_internals


### PR DESCRIPTION
change ordering criteria for `to_rotate` tab in Scheduling