### PR TITLE
Replace 'actual' with 'current'

### DIFF
--- a/app/assets/javascripts/backbone/models/user.coffee
+++ b/app/assets/javascripts/backbone/models/user.coffee
@@ -3,7 +3,7 @@ class Hrguru.Models.User extends Backbone.Model
   visibleBy:
     users: true
     roles: true
-    actualProjects: true
+    currentProjects: true
     oldProjects: true
     abilities: true
     months_in_current_project: true
@@ -18,7 +18,7 @@ class Hrguru.Models.User extends Backbone.Model
 
   updateVisibility: (data) ->
     @visibleBy.roles = @visibleByRoles(data.roles)
-    @visibleBy.actualProjects = @visibleByProjects(data.actualProjects)
+    @visibleBy.currentProjects = @visibleByProjects(data.currentProjects)
     @visibleBy.oldProjects = @visibleByOldProjects(data.oldProjects)
     @visibleBy.users = @visibleByUsers(data.users)
     @visibleBy.abilities = @visibleByAbilities(data.abilities)
@@ -27,7 +27,7 @@ class Hrguru.Models.User extends Backbone.Model
     @trigger 'toggle_visible', @isVisible()
 
   isVisible: ->
-    @visibleBy.roles && @visibleBy.actualProjects && @visibleBy.users &&
+    @visibleBy.roles && @visibleBy.currentProjects && @visibleBy.users &&
       @visibleBy.abilities && @isActive() && @visibleBy.months_in_current_project &&
       @visibleBy.category && @visibleBy.oldProjects
 

--- a/app/assets/javascripts/backbone/templates/dashboard/projects/project_wrapper.hamlc
+++ b/app/assets/javascripts/backbone/templates/dashboard/projects/project_wrapper.hamlc
@@ -3,7 +3,7 @@
     .project-name
       .project-avatar{style: "background-color: #{@.color}"}
         #{@.initials}
-      .actual-name
+      .current-name
         != @link_to @name, Routes.project_path(@id)
 
         %span.action

--- a/app/assets/stylesheets/controllers/projects.scss
+++ b/app/assets/stylesheets/controllers/projects.scss
@@ -115,7 +115,7 @@ $project-height: 45px;
     letter-spacing: -1px;
   }
 
-  .actual-name {
+  .current-name {
     position: absolute;
     top: 0;
     left: 0;

--- a/app/react/actions/UserFilterActions.js
+++ b/app/react/actions/UserFilterActions.js
@@ -3,7 +3,7 @@ import alt from '../alt';
 class UserFilterActions {
   constructor() {
     this.generateActions(
-      'changeActualProjectIds',
+      'changeCurrentProjectIds',
       'changePreviousProjectIds',
       'changeRoleIds',
       'changeUserIds'

--- a/app/react/components/projects/project-name.jsx
+++ b/app/react/components/projects/project-name.jsx
@@ -48,7 +48,7 @@ export default class ProjectName extends React.Component {
           <div className="project-avatar" style={avatarStyles}>
             {project.initials}
           </div>
-          <div className="actual-name">
+          <div className="current-name">
             <a href={Routes.project_path(project.id)}>{project.name}</a>
             <span className="action">
               {archiveIcon}

--- a/app/react/components/users/filters.jsx
+++ b/app/react/components/users/filters.jsx
@@ -21,12 +21,12 @@ export default class Filters extends React.Component {
     UserFilterActions.changeUserIds(userIds);
   }
 
-  handleFilterActualProjectsChange(values) {
+  handleFilterCurrentProjectsChange(values) {
     let projectIds = [];
     if(values != '') {
       projectIds = values.split(',').map(value => Number(value));
     }
-    UserFilterActions.changeActualProjectIds(projectIds);
+    UserFilterActions.changeCurrentProjectIds(projectIds);
   }
 
   handleFilterPreviousProjectsChange(values) {
@@ -74,7 +74,7 @@ export default class Filters extends React.Component {
       return roleFilterOptions[optionIndex];
     });
 
-    const actualProjectsSelectValue = UserFilterStore.getState().actualProjectIds.map(projectId => {
+    const currentProjectsSelectValue = UserFilterStore.getState().currentProjectIds.map(projectId => {
       const optionIds = projectFilterOptions.map(option => option.value);
       let optionIndex = optionIds.indexOf(projectId);
       return projectFilterOptions[optionIndex];
@@ -104,11 +104,11 @@ export default class Filters extends React.Component {
               onChange={this.handleFilterRoleChange} />
           </div>
           <div className="projects">
-            <Select name="projects-actual" placeholder="Filter by actual projects..." type="text"
+            <Select name="projects-current" placeholder="Filter by current projects..." type="text"
               multi={true}
               options={projectFilterOptions}
-              value={actualProjectsSelectValue}
-              onChange={this.handleFilterActualProjectsChange} />
+              value={currentProjectsSelectValue}
+              onChange={this.handleFilterCurrentProjectsChange} />
           </div>
           <div className="projects">
             <Select name="projects-old" placeholder="Filter by previous projects..." type="text"

--- a/app/react/components/users/users.jsx
+++ b/app/react/components/users/users.jsx
@@ -45,11 +45,11 @@ export default class Users extends React.Component {
     if(store.roleIds.length > 0) {
       users = users.filter(user => user.primary_roles[0] && store.roleIds.indexOf(user.primary_roles[0].id) > -1);
     }
-    if(store.actualProjectIds.length > 0) {
+    if(store.currentProjectIds.length > 0) {
       users = users.filter(user => {
-        const actualFilteredProjects = ProjectStore.getCurrentProjectsForUser(user.id)
-          .filter(project => store.actualProjectIds.indexOf(project.id) > -1);
-        return actualFilteredProjects.length > 0;
+        const currentFilteredProjects = ProjectStore.getCurrentProjectsForUser(user.id)
+          .filter(project => store.currentProjectIds.indexOf(project.id) > -1);
+        return currentFilteredProjects.length > 0;
       });
     }
     if(store.previousProjectIds.length > 0) {

--- a/app/react/stores/UserFiltersStore.js
+++ b/app/react/stores/UserFiltersStore.js
@@ -5,14 +5,14 @@ import UserFilterActions from '../actions/UserFilterActions';
 class UserFiltersStore {
   constructor() {
     this.bindActions(UserFilterActions);
-    this.actualProjectIds = [];
+    this.currentProjectIds = [];
     this.previousProjectIds = [];
     this.roleIds = [];
     this.userIds = [];
   }
 
-  changeActualProjectIds(projectIds) {
-    this.setState({ actualProjectIds: projectIds });
+  changeCurrentProjectIds(projectIds) {
+    this.setState({ currentProjectIds: projectIds });
   }
 
   changePreviousProjectIds(projectIds) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
       filters:
         users: 'Filter users…'
         roles: 'Filter roles…'
-        actual_projects: 'Filter by actual projects…'
+        current_projects: 'Filter by current projects…'
         old_projects: 'Filter by previous projects...'
         abilities: 'Filter abilities…'
       table:

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -60,7 +60,7 @@ describe ProjectsController do
 
   describe '#update' do
     let!(:project) { create(:project, name: 'hrguru') }
-    let(:actual_membership) { create(:membership, starts_at: 1.week.ago, ends_at: 1.week.from_now, stays: true, project: new_project) }
+    let(:current_membership) { create(:membership, starts_at: 1.week.ago, ends_at: 1.week.from_now, stays: true, project: new_project) }
     let(:old_membership) { create(:membership, starts_at: 2.weeks.ago, ends_at: 1.week.ago, stays: false, project: new_project) }
     let(:slack_config) { OpenStruct.new(webhook_url: 'webhook_url', username: 'PeopleApp') }
     let(:response_ok) { Net::HTTPOK.new('1.1', 200, 'OK') }
@@ -73,13 +73,13 @@ describe ProjectsController do
         allow_any_instance_of(Membership).to receive(:notify_slack_on_create)
         allow_any_instance_of(Membership).to receive(:notify_slack_on_update)
         expect_any_instance_of(Slack::Notifier).to receive(:ping).and_return(response_ok)
-        new_project.memberships << [actual_membership, old_membership]
+        new_project.memberships << [current_membership, old_membership]
         put :update, id: new_project, project: attributes_for(:project, potential: false)
         new_project.reload
       end
 
-      it 'return actual membership' do
-        expect(new_project.memberships).to match_array([actual_membership])
+      it 'return current membership' do
+        expect(new_project.memberships).to match_array([current_membership])
       end
 
       it 'deletes unnecessary memberships' do
@@ -99,7 +99,7 @@ describe ProjectsController do
       let!(:new_project) { create(:project, potential: false) }
 
       before do
-        new_project.memberships << [actual_membership, old_membership]
+        new_project.memberships << [current_membership, old_membership]
         allow(AppConfig).to receive(:slack).and_return(slack_config)
         expect_any_instance_of(Slack::Notifier).to receive(:ping).and_return(response_ok)
       end
@@ -108,7 +108,7 @@ describe ProjectsController do
         put :update, id: new_project, project: attributes_for(:project, potential: true)
         new_project.reload
         expect(new_project.memberships).to match_array([
-          actual_membership, old_membership])
+          current_membership, old_membership])
       end
     end
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -19,7 +19,7 @@ describe "Users page", js: true do
   context 'role names' do
     let!(:previous_position) { create(:position, user: developer, primary: false) }
 
-    it 'shows only actual role name' do
+    it 'shows only current role name' do
       expect(page).not_to have_content(previous_position.role.name)
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -9,15 +9,15 @@ describe Project do
   it { should validate_uniqueness_of(:name).case_insensitive }
 
   describe "pm" do
-    let(:actual_membership) { build(:membership, starts_at: 1.week.ago, ends_at: 1.week.from_now) }
+    let(:current_membership) { build(:membership, starts_at: 1.week.ago, ends_at: 1.week.from_now) }
     let(:old_membership) { build(:membership, starts_at: 2.weeks.ago, ends_at: 1.week.ago) }
     let(:future_membership) { build(:membership, starts_at: 1.week.from_now, ends_at: 2.weeks.from_now) }
 
     before do
-      allow(Membership).to receive(:with_role).and_return([actual_membership, old_membership, future_membership])
+      allow(Membership).to receive(:with_role).and_return([current_membership, old_membership, future_membership])
     end
 
-    its(:pm) { should eq(actual_membership.user) }
+    its(:pm) { should eq(current_membership.user) }
     its(:pm) { should_not eq(old_membership.user) }
     its(:pm) { should_not eq(future_membership.user) }
   end

--- a/spec/services/memberships/update_booked_at_spec.rb
+++ b/spec/services/memberships/update_booked_at_spec.rb
@@ -22,7 +22,7 @@ describe Memberships::UpdateBookedAt do
           membership.booked = true
         end
 
-        it 'changes booked_at to actual time' do
+        it 'changes booked_at to current time' do
           subject
           expect(membership.booked_at.utc.to_s).to eq Time.zone.now.utc.to_s
         end

--- a/spec/services/scheduling/booked_check_spec.rb
+++ b/spec/services/scheduling/booked_check_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Scheduling::BookedCheck do
   let!(:user) { create(:user) }
   let!(:expired_booked_membership) { create(:membership, :booked_expired, user: user) }
-  let!(:actual_booked_membership) { create(:membership, :booked, user: user) }
+  let!(:current_booked_membership) { create(:membership, :booked, user: user) }
 
 
   subject { described_class.new.call }
@@ -16,7 +16,7 @@ describe Scheduling::BookedCheck do
 
     it 'leaves booked memberships that are still before expiration date' do
       subject
-      expect(user.reload.memberships).to include(actual_booked_membership)
+      expect(user.reload.memberships).to include(current_booked_membership)
     end
   end
 end


### PR DESCRIPTION
Contexts where 'actual' is used as a synonym for 'current' are very rare in English, so we can safely treat it as a false friend here, and since we have been using the word 'current' in the app everywhere so far, we should not confuse devs and users by mixing it with 'actual' in some parts of the code, willy-nilly :).