### PR TITLE
Fix projects user display [PEOPLE-35]

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,6 +7,9 @@ class DashboardController < ApplicationController
       each_serializer: ProjectSerializer
     ).as_json
   end
+  expose(:users) do
+    User.includes(:memberships, :primary_roles).active.order(:last_name, :first_name)
+  end
   expose(:users_json) do
     ActiveModel::ArraySerializer.new(
       users.decorate,
@@ -14,9 +17,6 @@ class DashboardController < ApplicationController
     ).as_json
   end
   expose(:projects) { projects_repository.active_with_memberships.order(:name) }
-  expose(:users) do
-    User.includes(:memberships, :primary_roles).order(:last_name, :first_name)
-  end
   expose(:memberships) do
     Membership.where(project_id: projects.ids)
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,7 @@
 class DashboardController < ApplicationController
   include ContextFreeRepos
 
+  expose(:projects) { projects_repository.active_with_memberships.order(:name) }
   expose(:projects_json) do
     ActiveModel::ArraySerializer.new(
       projects.decorate,
@@ -16,7 +17,6 @@ class DashboardController < ApplicationController
       each_serializer: UserSerializer
     ).as_json
   end
-  expose(:projects) { projects_repository.active_with_memberships.order(:name) }
   expose(:memberships) do
     Membership.where(project_id: projects.ids)
   end

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -35,7 +35,7 @@ class PositionsController < ApplicationController
     if position.destroy
       redirect_to request.referer, notice: I18n.t('positions.success', type: 'delete')
     else
-      redirect_to request.referer, alert: I18n.t('positions.error',  type: 'delete')
+      redirect_to request.referer, alert: I18n.t('positions.error', type: 'delete')
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
     UserShowPage.new(
       user: user,
       projects_repository: projects_repository,
-      user_projects_repository: user_projects_repository,
+      user_projects_repository: user_projects_repository
     )
   end
   expose(:user_details_page) do
@@ -35,7 +35,7 @@ class UsersController < ApplicationController
       abilities_repository: abilities_repository,
       user_positions_repository: user_positions_repository,
       contract_types_repository: contract_types_repository,
-      user_roles_repository: user_roles_repository,
+      user_roles_repository: user_roles_repository
     )
   end
 

--- a/app/react/components/projects/project-filters.jsx
+++ b/app/react/components/projects/project-filters.jsx
@@ -63,7 +63,6 @@ export default class ProjectFilters extends React.Component {
       FilterActions.highlightNotBillable(e.target.checked);
     }
 
-
     return(
       <div id="filters">
         <div className="filters">

--- a/app/react/components/projects/project.jsx
+++ b/app/react/components/projects/project.jsx
@@ -49,14 +49,9 @@ export default class Project extends React.Component {
     const billableMemberships = MembershipStore.billableMemberships(this.state.project.id);
     const nonBillableMemberships = MembershipStore.nonBillableMemberships(this.state.project.id);
 
-    const activeBillableMemberships = billableMemberships
-      .filter(membership => membership.ends_at == null || moment(membership.ends_at) > moment());
-    const activeNonBillableMemberships = nonBillableMemberships
-      .filter(membership => membership.ends_at == null || moment(membership.ends_at) > moment());
-
-    const billableMembershipsRows = activeBillableMemberships
+    const billableMembershipsRows = billableMemberships
       .map(membership => <Membership key={membership.id} membership={membership} />);
-    const nonBillableMembershipsRows = activeNonBillableMemberships
+    const nonBillableMembershipsRows = nonBillableMemberships
       .map(membership => <Membership key={membership.id} membership={membership} />);
 
     const notes = ProjectStore.getNotesForProject(this.state.project.id);

--- a/app/react/components/projects/projects.jsx
+++ b/app/react/components/projects/projects.jsx
@@ -9,7 +9,6 @@ import SelectedMembershipStore from '../../stores/SelectedMembershipStore';
 import EditMembershipModal from './edit-membership-modal';
 import FilterStore from '../../stores/FilterStore';
 
-
 export default class Projects extends React.Component {
   constructor(props) {
     super(props);

--- a/app/react/components/users/filters.jsx
+++ b/app/react/components/users/filters.jsx
@@ -6,7 +6,6 @@ import UserFilterStore from '../../stores/UserFiltersStore';
 import UserFilterActions from '../../actions/UserFilterActions';
 import Select from 'react-select';
 
-
 export default class Filters extends React.Component {
   constructor(props) {
     super(props);
@@ -14,7 +13,6 @@ export default class Filters extends React.Component {
 
   handleFilterUserChange(values) {
     let userIds = [];
-    debugger;
     if(values != '') {
       userIds = values.split(',').map(value => Number(value));
     }

--- a/app/react/components/users/users.jsx
+++ b/app/react/components/users/users.jsx
@@ -37,7 +37,6 @@ export default class Users extends React.Component {
   }
 
   _filtersChanged(store) {
-    debugger;
     let users = UserStore.getState().users;
     if(store.userIds.length > 0) {
       users = users.filter(user => store.userIds.indexOf(user.id) > -1);

--- a/app/react/stores/MembershipStore.js
+++ b/app/react/stores/MembershipStore.js
@@ -42,11 +42,15 @@ class MembershipStore {
   }
 
   static billableMemberships(projectId) {
-    return this.memberships(projectId).filter(membership => membership.billable == true);
+    return this.memberships(projectId)
+      .filter(membership => membership.billable == true &&
+        (membership.ends_at == null || Moment(membership.ends_at) > Moment()));
   }
 
   static nonBillableMemberships(projectId) {
-    return this.memberships(projectId).filter(membership => membership.billable == false);
+    return this.memberships(projectId)
+      .filter(membership => membership.billable == false &&
+        (membership.ends_at == null || Moment(membership.ends_at) > Moment()));
   }
 
   static memberships(projectId) {

--- a/app/react/stores/MembershipStore.js
+++ b/app/react/stores/MembershipStore.js
@@ -43,14 +43,14 @@ class MembershipStore {
 
   static billableMemberships(projectId) {
     return this.memberships(projectId)
-      .filter(membership => membership.billable == true &&
-        (membership.ends_at == null || Moment(membership.ends_at) > Moment()));
+      .filter(membership => membership.billable === true &&
+        (membership.ends_at === null || Moment(membership.ends_at) > Moment()));
   }
 
   static nonBillableMemberships(projectId) {
     return this.memberships(projectId)
-      .filter(membership => membership.billable == false &&
-        (membership.ends_at == null || Moment(membership.ends_at) > Moment()));
+      .filter(membership => membership.billable === false &&
+        (membership.ends_at === null || Moment(membership.ends_at) > Moment()));
   }
 
   static memberships(projectId) {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,7 @@ end
 contract_types.each do |name|
   ContractType.find_or_create_by(name: name)
 end
+
 locations.each do |name|
   Location.find_or_create_by(name: name)
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -165,7 +165,6 @@ describe 'Projects page', js: true do
     end
 
     context 'when adding invalid project' do
-
       context 'when name is not present' do
         it 'fails with error message' do
           find('.btn-success').click


### PR DESCRIPTION
1) Some users that are not displayed in the Users list were available for selection in the Projects dashboard. They were archived users and, obviously, should not find their way to those dropdowns.

2) Users who were no longer in the project and didn't show up (but still had the old membership) were included in the billable/nonbillable counter in the Project tab. They no longer are.

+ minor corrections found by the linter 

JIRA: https://netguru.atlassian.net/browse/PEOPLE-35