### PR TITLE
Set `booked_at` date based on `starts_at` date set by user [PEOPLE-13]

### DIFF
--- a/app/services/memberships/update_booked_at.rb
+++ b/app/services/memberships/update_booked_at.rb
@@ -5,8 +5,7 @@ module Memberships
     end
 
     def call
-      return unless @membership.booked_changed?
-      booked_date = @membership.booked ? Time.zone.now : nil
+      booked_date = @membership.booked ? @membership.starts_at : nil
       @membership.booked_at = booked_date
     end
   end

--- a/spec/services/memberships/update_booked_at_spec.rb
+++ b/spec/services/memberships/update_booked_at_spec.rb
@@ -22,16 +22,16 @@ describe Memberships::UpdateBookedAt do
           membership.booked = true
         end
 
-        it 'changes booked_at to current time' do
+        it 'changes booked_at to starts_at date' do
           subject
-          expect(membership.booked_at.utc.to_s).to eq Time.zone.now.utc.to_s
+          expect(membership.booked_at.to_date).to eq membership.starts_at
         end
       end
     end
 
     context 'booked has not changed' do
       it 'does not change booked_at' do
-        expect{ subject }.not_to change { membership.reload.booked_at }
+        expect { subject }.not_to change { membership.reload.booked_at }
       end
     end
   end


### PR DESCRIPTION
Before `booked_at` date was always set to the date when booking was created.
Now user can specify when booking starts and update it.