### PR TITLE
Fix users project display [PEOPLE-7]

### DIFF
--- a/app/react/components/projects/membership.jsx
+++ b/app/react/components/projects/membership.jsx
@@ -34,9 +34,6 @@ export default class Membership extends React.Component {
     if(highlightNonBillable) {
       const user = ProjectUsersStore.getUser(this.props.membership.user_id);
       const userPrimaryRole = user.primary_roles[0]
-      if(this.props.membership.user_id == 51 && this.props.membership.project_id == 1) {
-        debugger;
-      }
       result = this.props.membership.role_id == userPrimaryRole.id && userPrimaryRole.billable && !this.props.membership.billable;
     }
     return result;

--- a/app/react/stores/ProjectStore.js
+++ b/app/react/stores/ProjectStore.js
@@ -41,6 +41,7 @@ class ProjectStore {
       .filter(membership => membership.user_id == userId)
       .filter(membership => Moment(membership.starts_at) < Moment())
       .filter(membership => (membership.ends_at == null || Moment(membership.ends_at) > Moment()))
+      .filter(membership => !membership.booked)
       .map(membership => membership.project_id);
     return this.state.projects.filter(project => userCurrentMembershipsProjectIds.indexOf(project.id) > -1);
   }


### PR DESCRIPTION
It seems that the Users tab displays everything correctly on staging/dev now; Production still has Backbone, so won't work properly until we finally deploy. Some booked projects appeared twice - in the Booked section and other sections, this is now fixed. + some old debugging artifact got removed.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-7