### PR TITLE
Show/hide maintenance datepicker dynamically [PEOPLE-42]

### DIFF
--- a/app/assets/javascripts/common/project_form.coffee
+++ b/app/assets/javascripts/common/project_form.coffee
@@ -1,0 +1,9 @@
+changeMaintenanceState = ->
+  $('#project_project_type').change (event) ->
+    if $(event.target).val() == 'maintenance'
+      $('#maintenance_wrapper').removeClass('hidden')
+    else
+      $('#maintenance_wrapper').addClass('hidden')
+
+$ ->
+  changeMaintenanceState()


### PR DESCRIPTION
When editing a project or making  anew one, the Type dropdown did not cause the maintenance datepicker to show/hide. It only appeared when page got reloaded with errors in the form.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-42