### PR TITLE
Change unavailable booked priority [PEOPLE-2]

### DIFF
--- a/app/repositories/scheduled_users_repository.rb
+++ b/app/repositories/scheduled_users_repository.rb
@@ -60,7 +60,7 @@ class ScheduledUsersRepository
 
   def unavailable
     UnavailableProjectBuilder.new.call
-    @unavailable ||= technical_users.not_booked.unavailable
+    @unavailable ||= technical_users.unavailable
   end
 
   def technical

--- a/spec/repositories/scheduled_users_repository_spec.rb
+++ b/spec/repositories/scheduled_users_repository_spec.rb
@@ -198,8 +198,8 @@ describe ScheduledUsersRepository do
         unavailable[:dev_without_due_date][:with_internal_project_scheduled])
     end
 
-    it 'doesn\'t include others' do
-      expect(subject.length).to eq(6)
+    it 'does include booked' do
+      expect(subject.length).to eq(8)
     end
   end
 end


### PR DESCRIPTION
Booked users assigned to project Unavailable will show up in both 'unavailable' and 'booked' tabs in Scheduling