### PR TITLE
PEOPLE-54 user project order

### DIFF
--- a/app/view_objects/user_show_page.rb
+++ b/app/view_objects/user_show_page.rb
@@ -16,6 +16,12 @@ class UserShowPage
     projects_repository.with_notes
   end
 
+  def user_all_memberships
+    MembershipDecorator.decorate_collection(
+      user.object.memberships.includes(:project).reorder(starts_at: :desc, ends_at: :desc)
+    )
+  end
+
   def user_active_memberships
     MembershipDecorator.decorate_collection(
       user.object.memberships.active.includes(:project).reorder(ends_at: :desc, starts_at: :desc)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,12 +14,9 @@
     = render 'positions', details_page: user_details_page
 
     .list-group
-      - user_show_page.user_booked_memberships.each do |membership|
-        = render partial: 'membership', locals: { membership: membership }
-      - user_show_page.user_active_memberships.each do |membership|
-        = render partial: 'membership', locals: { membership: membership }
-      - user_show_page.user_archived_memberships.each do |membership|
-        = render partial: 'membership', locals: { membership: membership }
+      - user_show_page.user_all_memberships.each do |membership|
+        - unless membership.project.potential? && !membership.booked?
+          = render partial: 'membership', locals: { membership: membership }
 
   .time-section
     .timeline

--- a/spec/view_objects/user_show_page_spec.rb
+++ b/spec/view_objects/user_show_page_spec.rb
@@ -19,6 +19,19 @@ describe UserShowPage do
     )
   end
 
+  describe '#user_all_memberships' do
+    let(:instance) do
+      described_class.new(user: user, projects_repository: nil, user_projects_repository: nil)
+    end
+
+    it 'returns all memberships of the user' do
+      expected_memberships = Membership.where(user: user)
+      memberships = instance.user_all_memberships
+
+      expect(memberships.map(&:id).sort).to eql(expected_memberships.map(&:id).sort)
+    end
+  end
+
   describe '#user_active_memberships' do
     let(:instance) do
       described_class.new(user: user, projects_repository: nil, user_projects_repository: nil)


### PR DESCRIPTION
The projects in the user's profile should be displayed sorted by membership start date. They should never break this order for any reason (currently, for example, archived project memberships are displayed always at the bottom). Also, potential memberships should only display when the user is booked in such membership.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-54