### PR TITLE
PEOPLE-7 potential projects in current

### DIFF
--- a/app/react/components/projects/edit-membership-modal.jsx
+++ b/app/react/components/projects/edit-membership-modal.jsx
@@ -139,6 +139,12 @@ export default class EditMembershipModal extends React.Component {
               onClick={changeBillable}></input>
             <label>Billable</label>
           </div>
+          <div>
+            <input id="isBooked" type="checkbox"
+              defaultChecked={this.state.membership.booked}
+              onClick={changeBooked}></input>
+            <label>Booked</label>
+          </div>
         </div>
         <div className="modal-footer">
           <button type="button" className="btn btn-default" onClick={closeModal}>Close</button>

--- a/app/react/components/projects/edit-membership-modal.jsx
+++ b/app/react/components/projects/edit-membership-modal.jsx
@@ -93,6 +93,7 @@ export default class EditMembershipModal extends React.Component {
     const showStartDatePicker = () => this.setState({ showStartDate: true, showEndDate: false });
     const showEndDatePicker = () => this.setState({ showStartDate: false, showEndDate: true });
     const changeBillable = () => this.setState({ billable: !this.state.billable });
+    const changeBooked = () => this.setState({ booked: !this.state.booked });
 
     return(
       <Modal

--- a/app/react/components/projects/edit-membership-modal.jsx
+++ b/app/react/components/projects/edit-membership-modal.jsx
@@ -68,6 +68,7 @@ export default class EditMembershipModal extends React.Component {
       const params = {
         id: this.state.membership.id,
         billable: this.state.billable,
+        booked: this.state.booked,
         starts_at: this.state.startDate,
         ends_at: this.state.endDate
       };

--- a/app/react/stores/ProjectStore.js
+++ b/app/react/stores/ProjectStore.js
@@ -45,6 +45,7 @@ class ProjectStore {
       .map(membership => membership.project_id);
     return this.state.projects
       .filter(project => userCurrentMembershipsProjectIds.indexOf(project.id) > -1)
+      .filter(project => !project.potential)
       .filter(project => (project.end_at == null ||
         Moment(project.end_at).format('YYYY-MM-DD') >= Moment().format('YYYY-MM-DD')));
   }


### PR DESCRIPTION
Note: this is not the main issue of this ticket, it's an additional thing found by the QA. 

Projects that are potential and whose start date is in the past were displayed in the user's Current project list. They should not be visible ANYWHERE unless the user is booked for that project, in which case such project should be displayed in the Booked section and in their profile.

+ Since potential unbooked projects/memberships are now not shown anywhere, we need a way to edit such membership. I added a checkbox for the 'booked' parameter in the modal in the Projects view.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-7