### PR TITLE
PEOPLE-51 detect billable roles

### DIFF
--- a/app/react/components/projects/add-user-to-project.jsx
+++ b/app/react/components/projects/add-user-to-project.jsx
@@ -10,9 +10,13 @@ export default class AddUserToProject extends React.Component {
   }
 
   createMembership(userId) {
+    const user = ProjectUsersStore.getUser(userId);
+    const billableRole = user.primary_roles[0].billable;
+
     MembershipActions.create({
       userId: userId,
-      projectId: this.props.project.id
+      projectId: this.props.project.id,
+      billable: billableRole
     });
   }
 

--- a/app/react/sources/MembershipSource.js
+++ b/app/react/sources/MembershipSource.js
@@ -2,7 +2,7 @@ import ProjectUsersStore from '../stores/ProjectUsersStore';
 
 export default class MembershipSource {
   static create(params) {
-    const { userId, projectId } = params;
+    const { userId, projectId, billable } = params;
     const roleId = ProjectUsersStore.getUser(userId).primary_roles[0].id;
     return $.ajax({
       url: Routes.memberships_path(),
@@ -12,7 +12,7 @@ export default class MembershipSource {
         membership: {
           user_id: userId,
           project_id: projectId,
-          billable: true,
+          billable: billable,
           starts_at: new Date(),
           role_id: roleId
         }


### PR DESCRIPTION
When adding users to projects from the Projects section, they were always assigned as billable (`billable: true`), regardless of the primary role's billable parameter. Now the user will be assigned as billable/nonbillable based on their role, this is how it used to work on the production when Backbone was around.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-51