### PR TITLE
PEOPLE-57 Include current day as project membership day

### DIFF
--- a/app/react/stores/ProjectStore.js
+++ b/app/react/stores/ProjectStore.js
@@ -40,14 +40,15 @@ class ProjectStore {
     const userCurrentMembershipsProjectIds = MembershipStore.getState().memberships
       .filter(membership => membership.user_id == userId)
       .filter(membership => Moment(membership.starts_at) < Moment())
-      .filter(membership => (membership.ends_at == null || Moment(membership.ends_at) > Moment()))
+      .filter(membership => (membership.ends_at == null ||
+        Moment(membership.ends_at).startOf('day') >= Moment().startOf('day')))
       .filter(membership => !membership.booked)
       .map(membership => membership.project_id);
     return this.state.projects
       .filter(project => userCurrentMembershipsProjectIds.indexOf(project.id) > -1)
       .filter(project => !project.potential)
       .filter(project => (project.end_at == null ||
-        Moment(project.end_at).format('YYYY-MM-DD') >= Moment().format('YYYY-MM-DD')));
+        Moment(project.end_at).startOf('day') >= Moment().startOf('day')));
   }
 
   static getNextProjectsForUser(userId) {


### PR DESCRIPTION
Projects that were ending today were not displayed as current. But they should.

Also, I'm not comparing dates using Moment's #startOf which is the right way to do it.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-57