### PR TITLE
PEOPLE-58 Nonbillable indicator issue

### DIFF
--- a/app/assets/stylesheets/controllers/users.scss
+++ b/app/assets/stylesheets/controllers/users.scss
@@ -159,3 +159,9 @@ body.users {
   margin-left: 3px;
   height: 50px;
 }
+
+.inline.project {
+  .glyphicon {
+    margin-right: 5px;
+  }
+}

--- a/app/react/stores/MembershipStore.js
+++ b/app/react/stores/MembershipStore.js
@@ -67,7 +67,7 @@ class MembershipStore {
       return membership.user_id == userId && membership.project_id == projectId;
     });
     if(membership.length > 0) {
-      return membership[0];
+      return membership[membership.length - 1];
     }
     return null;
   }


### PR DESCRIPTION
The non-billable indicator was displayed taking under consideration user's FIRST membership in a project. This means that when that user was initially a junior in a project and later on was assigned to the same project as a dev, even though the new membership was billable, the non-billable indicator was still displayed. Instead we should consider the newest membership when displaying the exclamation mark.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-58