### PR TITLE
PEOPLE-58 Sort memberships by starts_at before selecting last

### DIFF
--- a/app/react/stores/MembershipStore.js
+++ b/app/react/stores/MembershipStore.js
@@ -66,8 +66,18 @@ class MembershipStore {
     const membership = this.state.memberships.filter(membership => {
       return membership.user_id == userId && membership.project_id == projectId;
     });
+
+    const compare = (a, b) => {
+      if (a.starts_at < b.starts_at) {
+        return -1;
+      } else if (a.starts_at > b.starts_at) {
+        return 1;
+      }
+      return 0;
+    }
+
     if(membership.length > 0) {
-      return membership[membership.length - 1];
+      return membership.sort(compare)[membership.length - 1];
     }
     return null;
   }


### PR DESCRIPTION
Turns out JavaScript doesn't always act smart when selecting the last element in an array...I added some assistance enforcing sort by membership start date.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-58