### PR TITLE
PEOPLE-60 Filtering people for projects

### DIFF
--- a/app/react/components/projects/add-user-to-project.jsx
+++ b/app/react/components/projects/add-user-to-project.jsx
@@ -21,7 +21,7 @@ export default class AddUserToProject extends React.Component {
   }
 
   render() {
-    const users = ProjectUsersStore.getUsersWithoutProject(this.props.project.id);
+    const users = ProjectUsersStore.getUsersNotInProjectNow(this.props.project.id);
     const options = users.map(user => {
       return { label: `${user.last_name} ${user.first_name}`, value: user.id };
     });

--- a/app/react/stores/ProjectUsersStore.js
+++ b/app/react/stores/ProjectUsersStore.js
@@ -17,7 +17,7 @@ class ProjectUsersStore {
     return null;
   }
 
-  static getUsersWithoutProject(projectId) {
+  static getUsersNotInProjectNow(projectId) {
     const userIdsInProject = MembershipStore
       .memberships(projectId)
       .map(membership => membership.user_id);

--- a/app/react/stores/ProjectUsersStore.js
+++ b/app/react/stores/ProjectUsersStore.js
@@ -2,6 +2,7 @@ import alt from '../alt';
 
 import ProjectUsersActions from '../actions/ProjectUsersActions';
 import MembershipStore from './MembershipStore';
+import Moment from 'moment';
 
 class ProjectUsersStore {
   constructor() {
@@ -20,6 +21,7 @@ class ProjectUsersStore {
   static getUsersNotInProjectNow(projectId) {
     const userIdsInProject = MembershipStore
       .memberships(projectId)
+      .filter(membership => membership.ends_at === null || Moment(membership.ends_at) > Moment())
       .map(membership => membership.user_id);
 
     return this.state.users.filter(user => userIdsInProject.indexOf(user.id) == -1);


### PR DESCRIPTION
Dropdowns in the Projects section did not include users who had at least one membership in the given project, even when that membership ended a long time ago. Now we only filter out the ones that are in the project right now. Users can be added to the project multiple times again as long as these memberships don't overlap.

JIRA: https://netguru.atlassian.net/browse/PEOPLE-60