### PR TITLE
Change source for potential project parameter

### DIFF
--- a/app/serializers/api/v3/membership_serializer.rb
+++ b/app/serializers/api/v3/membership_serializer.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def potential
-        object.project.project_potential
+        object.project.potential
       end
     end
   end

--- a/app/serializers/api/v3/membership_serializer.rb
+++ b/app/serializers/api/v3/membership_serializer.rb
@@ -2,7 +2,7 @@ module Api
   module V3
     class MembershipSerializer < ActiveModel::Serializer
       attributes :project_name, :starts_at, :ends_at, :role_name, :project_internal, :booked,
-        :project_potential
+        :potential
 
       def project_name
         object.project.name
@@ -10,6 +10,10 @@ module Api
 
       def role_name
         object.role.name
+      end
+
+      def potential
+        object.project.project_potential
       end
     end
   end


### PR DESCRIPTION
Changes: project's `potential` parameter is now taken from project object.