### PR TITLE
Set booked to true when adding people to potential projects from dashboard [PEOPLE-97]

### DIFF
--- a/app/react/components/projects/add-user-to-project.jsx
+++ b/app/react/components/projects/add-user-to-project.jsx
@@ -12,13 +12,17 @@ export default class AddUserToProject extends React.Component {
   createMembership(userId) {
     const user = ProjectUsersStore.getUser(userId);
     const billableRole = user.primary_roles[0].billable;
-
-    MembershipActions.create({
+    let params = {
       userId: userId,
       projectId: this.props.project.id,
       billable: billableRole,
       project_potential: this.props.project.potential
-    });
+    };
+
+    if(this.props.project.potential) {
+      params.booked = true;
+    }
+    MembershipActions.create(params);
   }
 
   render() {

--- a/app/react/sources/MembershipSource.js
+++ b/app/react/sources/MembershipSource.js
@@ -2,7 +2,7 @@ import ProjectUsersStore from '../stores/ProjectUsersStore';
 
 export default class MembershipSource {
   static create(params) {
-    const { userId, projectId, billable } = params;
+    const { userId, projectId, billable, project_potential, booked } = params;
     const roleId = ProjectUsersStore.getUser(userId).primary_roles[0].id;
     return $.ajax({
       url: Routes.memberships_path(),
@@ -14,7 +14,9 @@ export default class MembershipSource {
           project_id: projectId,
           billable: billable,
           starts_at: new Date(),
-          role_id: roleId
+          role_id: roleId,
+          project_potential: project_potential,
+          booked: booked
         }
       }
     });

--- a/app/views/memberships/show.rabl
+++ b/app/views/memberships/show.rabl
@@ -1,3 +1,3 @@
 object membership
 extends 'memberships/base'
-attributes :project_potential
+attributes :project_potential, :booked


### PR DESCRIPTION
**JIRA:** https://netguru.atlassian.net/browse/PEOPLE-97


When adding a person to a potential project in Projects, created membership should have booked set to true.

**Changes:**
 - set booked to true when adding a person to a potential project in Projects
 - pass new fields into controller in MembershipSource
 - add booked attribute to memberships/show.rabl