### PR TITLE
Enable circleci feature tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-webkit'
+  gem 'selenium-webdriver'
   gem 'codeclimate-test-reporter', require: false
   gem 'database_cleaner'
   gem 'rack_session_access'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -543,6 +545,7 @@ GEM
       rest-client (~> 1.8.0)
     ruby_parser (3.6.5)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.0)
     safe_yaml (1.0.4)
     sass (3.4.19)
     sass-rails (5.0.4)
@@ -553,6 +556,11 @@ GEM
       tilt (>= 1.1, < 3)
     searchlight (4.1.0)
     selectize-rails (0.12.1)
+    selenium-webdriver (2.52.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.5.0)
     shellany (0.0.1)
     shoulda (3.5.0)
@@ -622,6 +630,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket (1.2.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
@@ -705,6 +714,7 @@ DEPENDENCIES
   sass-rails
   searchlight
   selectize-rails
+  selenium-webdriver
   shoulda
   simple_form
   slack-notifier

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -10,10 +10,12 @@
 
   .col-sm-6
     - if current_user.admin?
-      = render 'new_membership_form', membership_page: new_membership_page
-    = render 'positions', details_page: user_details_page
+      .user-new-membership
+        = render 'new_membership_form', membership_page: new_membership_page
+    .user-positions
+      = render 'positions', details_page: user_details_page
 
-    .list-group
+    .list-group.user-projects
       - user_show_page.user_all_memberships.each do |membership|
         - unless membership.project.potential? && !membership.booked?
           = render partial: 'membership', locals: { membership: membership }

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
   pre:
     - cp config/sec_config.yml.sample config/sec_config.yml
   post:
-    - npm run build
+    - npm install webpack -g
+    - webpack
   cache_directories:
     - "node_modules"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   ruby:
     version: 2.1.5
+  node:
+    version: 4.3.1
+
 deployment:
   master:
     branch: master

--- a/spec/features/project_potential_spec.rb
+++ b/spec/features/project_potential_spec.rb
@@ -10,7 +10,7 @@ describe 'Potential project', js: true do
       .serialize_into_session(admin_user).unshift('User')
   end
 
-  context 'when \'stays\' is unchecked' do
+  context "when 'stays' is unchecked" do
     let!(:membership) { create :membership, project: project, user: user }
 
     before do
@@ -31,7 +31,7 @@ describe 'Potential project', js: true do
     end
   end
 
-  context 'when \'stays\' is checked' do
+  context "when 'stays' is checked" do
     let!(:membership) { create :membership, project: project, user: user }
 
     before do
@@ -42,7 +42,7 @@ describe 'Potential project', js: true do
       expect(page).to have_content("#{user.decorate.name}")
     end
 
-    it 'doesn\'t delete membership when project is updated to nonpotential' do
+    it "doesn't delete membership when project is updated to nonpotential" do
       uncheck('Potential')
       click_button('Save')
       visit user_path(user)

--- a/spec/features/project_potential_spec.rb
+++ b/spec/features/project_potential_spec.rb
@@ -10,7 +10,7 @@ describe 'Potential project', js: true do
       .serialize_into_session(admin_user).unshift('User')
   end
 
-  context 'when stays is false' do
+  context 'when \'stays\' is unchecked' do
     let!(:membership) { create :membership, project: project, user: user }
 
     before do
@@ -22,14 +22,17 @@ describe 'Potential project', js: true do
     end
 
     it 'deletes membership when project is updated to nonpotential' do
+      uncheck(membership.user.decorate.name)
+      uncheck('Potential')
       click_button('Save')
       visit user_path(user)
-      expect(page).not_to have_content(project.name)
+      within('.user-projects') { expect(page).not_to have_content(project.name) }
+      within('.time-section') { expect(page).not_to have_content(project.name) }
     end
   end
 
-  context 'when stays is true' do
-    let!(:membership) { create :membership, project: project, user: user, stays: true }
+  context 'when \'stays\' is checked' do
+    let!(:membership) { create :membership, project: project, user: user }
 
     before do
       visit edit_project_path(project)
@@ -39,11 +42,11 @@ describe 'Potential project', js: true do
       expect(page).to have_content("#{user.decorate.name}")
     end
 
-    it 'dont delete membership when project is updated to nonpotential' do
+    it 'doesn\'t delete membership when project is updated to nonpotential' do
       uncheck('Potential')
       click_button('Save')
       visit user_path(user)
-      expect(page).to have_content(project.name)
+      within('.user-projects') { expect(page).to have_content(project.name) }
     end
   end
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -17,11 +17,16 @@ describe 'Projects page', js: true do
   let!(:note) { create(:note) }
 
   before do
+    Capybara.javascript_driver = :selenium
     allow_any_instance_of(SendMailJob).to receive(:perform)
     page.set_rack_session 'warden.user.user.key' => User
       .serialize_into_session(admin_user).unshift('User')
 
     visit '/dashboard' # Projects tab
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 
   describe 'tabs' do

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -43,18 +43,18 @@ describe 'Projects page', js: true do
         end
       end
 
-      xit 'displays action icon (archive) when hovered' do
+      it 'displays action icon (archive) when hovered' do
         expect(page.find('.archive')).to be_visible
       end
 
-      xit 'displays proper projects' do
+      it 'displays proper projects' do
         expect(page).to have_content(active_project.name)
         expect(page).not_to have_content(potential_project.name)
         expect(page).not_to have_content(archived_project.name)
         expect(page).not_to have_content(potential_archived_project.name)
       end
 
-      xit 'allows adding memberships to an active project' do
+      it 'allows adding memberships to an active project' do
         expect(page).to have_selector('.Select-placeholder')
       end
 
@@ -64,7 +64,7 @@ describe 'Projects page', js: true do
         end
 
         context 'when checked' do
-          xit 'shows future memberships' do
+          it 'shows future memberships' do
             visit '/dashboard'
             check 'show-next'
             expect(page).to have_content(future_membership.user.last_name)

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -17,16 +17,11 @@ describe 'Projects page', js: true do
   let!(:note) { create(:note) }
 
   before do
-    Capybara.javascript_driver = :selenium
     allow_any_instance_of(SendMailJob).to receive(:perform)
     page.set_rack_session 'warden.user.user.key' => User
       .serialize_into_session(admin_user).unshift('User')
 
     visit '/dashboard' # Projects tab
-  end
-
-  after do
-    Capybara.use_default_driver
   end
 
   describe 'tabs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,4 +64,6 @@ end
 
 Capybara.default_max_wait_time = 5
 
-Capybara.javascript_driver = :webkit
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new(app)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,3 +67,5 @@ Capybara.default_max_wait_time = 5
 Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.new(app)
 end
+
+Capybara.javascript_driver = :selenium


### PR DESCRIPTION
**Adds:**
- Selenium as the default feature spec driver
- new version of Node on CircleCI
- webpack builds React bundle on CircleCI
- unpended selected feature specs to ensure the solution works
- fixed a spec that should fail under capybara webkit but did not

We can finally start unpending feature specs that use React.