### PR TITLE
Change local variable name

### DIFF
--- a/app/repositories/memberships_repository.rb
+++ b/app/repositories/memberships_repository.rb
@@ -7,14 +7,14 @@ class MembershipsRepository
     Membership.unfinished.not_archived
   end
 
-  def upcoming_changes(days)
+  def upcoming_changes(number_of_days)
     # FIXME: it should be more friendly
     Membership.includes(:project)
       .where("(memberships.ends_at BETWEEN ? AND ?) OR (memberships.starts_at BETWEEN ? AND ?)",
              Time.now,
-             days.days.from_now,
+             number_of_days.days.from_now,
              Time.now,
-             days.days.from_now
+             number_of_days.days.from_now
             )
   end
 end


### PR DESCRIPTION
From time to time, rollbar reports `NoMethodError: undefined method `from_now' for 30:Fixnum`, the change of local variable name seems like a good idea, since the app may be confused with `days.days.from_now`