### PR TITLE
PEOPLE-109 Remove link to statistics

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -23,7 +23,6 @@
               %ul.dropdown-menu
                 %li{ class: menu_class('roles') }= link_to "Roles", roles_path
                 %li{ class: menu_class('abilities') }= link_to "Abilities", abilities_path
-                %li{ class: menu_class('statistics') }= link_to "Statistics", statistics_path
       - if signed_in?
         %ul.nav.navbar-nav.navbar-right.user-profile
           %li.dropdown


### PR DESCRIPTION
**Changes:**
- Statistics page should still be available, but there should not be any overt link to it in People app

**Jira:**
https://netguru.atlassian.net/browse/PEOPLE-109