### PR TITLE
include unstarted commercial projects in rotation in progress

### DIFF
--- a/app/repositories/scheduled_users_repository.rb
+++ b/app/repositories/scheduled_users_repository.rb
@@ -40,7 +40,7 @@ class ScheduledUsersRepository
     @with_rotations_in_progress ||=
       not_booked_billable_users
       .joins(memberships: :project)
-      .merge(Project.active.unfinished.started.commercial.not_maintenance)
+      .merge(Project.active.unfinished.commercial.not_maintenance)
       .merge(Membership.not_started.active.not_internal)
   end
 


### PR DESCRIPTION
Before users who have next membership in commercial unstarted project did not show up in rotation in progress tab. 
Now it shows also users with planned unstarted commercial projects.