### PR TITLE
change label archived to unavailable [PEOPLE-25]

### DIFF
--- a/app/react/components/teams/team-user.jsx
+++ b/app/react/components/teams/team-user.jsx
@@ -193,7 +193,7 @@ class TeamUser extends React.Component {
           </div>
           <div className='member-details'>
             {this.labelsRow()}
-            <div className='label label-info'>{ this.props.user.archived ? 'archived' : null }</div>
+            <div className='label label-info'>{ this.props.user.archived ? 'unavailable' : null }</div>
           </div>
         </div>
         {this.actions()}

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -122,7 +122,7 @@ describe 'Team view', js: true do
     it 'displays archived label for archived users' do
       team_user.update_attribute(:archived, true)
       teams_page.load
-      expect(page).to have_content('archived')
+      expect(page).to have_content('unavailable')
     end
   end
 


### PR DESCRIPTION
In teams tab when user is archived label should state `unavailable` instead of `archived`