### PR TITLE
Show toggle admin checkbox only if current user is admin

### DIFF
--- a/app/react/components/users/user.jsx
+++ b/app/react/components/users/user.jsx
@@ -28,6 +28,8 @@ export default class User extends React.Component {
 
     const userPrimaryRoleName = user.primary_roles[0] ? user.primary_roles[0].name : 'No primary role';
 
+    const toggleAdminSection = <input className="admin form-control" type="checkbox" checked={user.admin} onChange={toggleAdminForUser} />
+
     return(
       <tr style={styles}>
         <td>{this.props.number}</td>
@@ -69,8 +71,7 @@ export default class User extends React.Component {
             </div>
         </td>
         <td>
-            <input className="admin form-control" type="checkbox" checked={user.admin}
-              onChange={toggleAdminForUser} />
+          { this.props.isAdmin ? toggleAdminSection : "" }
         </td>
     </tr>
     );

--- a/app/react/components/users/users-table-header.jsx
+++ b/app/react/components/users/users-table-header.jsx
@@ -15,7 +15,7 @@ export default class UsersTableHeader extends React.Component {
           </th>
           <th>Employment</th>
           <th>Projects</th>
-          <th>Admin Role</th>
+          <th>{ this.props.isAdmin ? "Admin Role" : "" }</th>
         </tr>
       </thead>
     );

--- a/app/react/components/users/users.jsx
+++ b/app/react/components/users/users.jsx
@@ -16,7 +16,8 @@ export default class Users extends React.Component {
     MembershipStore.setInitialState(this.props.memberships);
     RoleStore.setInitialState(this.props.roles);
     this.state = {
-      users: UserStore.getState().users
+      users: UserStore.getState().users,
+      isAdmin: false
     }
     this._usersChanged = this._usersChanged.bind(this);
     this._filtersChanged = this._filtersChanged.bind(this);
@@ -63,12 +64,12 @@ export default class Users extends React.Component {
 
   render() {
     let i = 1;
-    const userRows = this.state.users.map(user => <User key={user.id} number={i++} user={user} />);
+    const userRows = this.state.users.map(user => <User key={user.id} number={i++} user={user} isAdmin={this.props.isAdmin} />);
     return(
       <div>
         <Filters/>
         <table id='users' className='table table-striped table-hover'>
-          <UsersTableHeader />
+          <UsersTableHeader isAdmin={this.props.isAdmin} />
           <tbody>
             {userRows}
           </tbody>

--- a/app/view_objects/user_index_page.rb
+++ b/app/view_objects/user_index_page.rb
@@ -1,10 +1,11 @@
 class UserIndexPage
-  def react_props
+  def react_props(current_user)
     {
       projects: serialized_projects,
       users: serialized_users,
       memberships: serialized_memberships,
-      roles: serialized_roles
+      roles: serialized_roles,
+      isAdmin: current_user.admin?
     }
   end
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,4 @@
 - if Flip.fetching_abilities? && current_user.admin?
   #fetch-button
     = link_to 'Fetch users skills from Profile', { controller: 'users', action: 'fetch_abilities' }, class: 'btn btn-success js-fetch-abilities'
-= react_component('users', users_index_page.react_props)
+= react_component('users', users_index_page.react_props(current_user) )

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -65,8 +65,20 @@ describe 'Users page', js: true do
 
     before { users_page.load }
 
-    it "shows potential sign" do
+    it 'shows potential sign' do
       expect(users_page).to have_potential_signs
     end
+  end
+
+  context 'hide toggle admin column if not admin' do
+    it { expect(users_page.has_toggle_admin_checkboxes?).to eq(false) }
+  end
+
+  context 'show toggle admin column if not admin' do
+    before do
+      developer.update(admin: true)
+      users_page.load
+    end
+    it { expect(users_page.has_toggle_admin_checkboxes?).to eq(true) }
   end
 end

--- a/spec/support/pages/users_page.rb
+++ b/spec/support/pages/users_page.rb
@@ -1,7 +1,8 @@
 class UsersPage < SitePrism::Page
   set_url '/users'
 
-  elements :user_rows, 'table.users tr'
+  elements :toggle_admin_checkboxes, 'table#users input.admin'
+  elements :user_rows, 'table#users tr'
   elements :nonbillable_signs, '.glyphicon.glyphicon-exclamation-sign.notbillable'
   elements :potential_signs, '.glyphicon.glyphicon-asterisk.potential'
 end


### PR DESCRIPTION
before any user could see toggle admin checkboxes  
**Changes:**
 - pass isAdmin as props into Users, User and UsersTableHeader components
 - show checkbox only if currently logged used is admin
 - update specs