### PR TITLE
reload project memberships in after_save callback

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -97,7 +97,7 @@ class Project < ActiveRecord::Base
   end
 
   def set_proper_membership_dates
-    memberships.each do |membership|
+    memberships.reload.each do |membership|
       if membership.stays
         membership.update(starts_at: Date.today)
       else


### PR DESCRIPTION
before when attribute `stays` was updated its change was not present in memberships associated with project (objects which were already fetched from DB).