### PR TITLE
Add Scheduling::Stats service

### DIFF
--- a/app/controllers/scheduling_controller.rb
+++ b/app/controllers/scheduling_controller.rb
@@ -21,18 +21,7 @@ class SchedulingController < ApplicationController
   end
 
   expose(:stats) do
-    stats = {
-      all: repository.all,
-      juniors_and_interns: repository.scheduled_juniors_and_interns,
-      to_rotate: repository.to_rotate,
-      in_internals: repository.in_internals,
-      with_rotations_in_progress: repository.with_rotations_in_progress,
-      in_commercial_projects_with_due_date: repository.in_commercial_projects_with_due_date,
-      booked: repository.booked,
-      unavailable: repository.unavailable,
-    }
-    stats[:not_scheduled] = repository.not_scheduled if current_user.admin?
-    stats.keys.each_with_object({}) { |key, h| h[key] = number_of(stats[key]) }
+    Scheduling::Stats.new(repository, current_user.admin?).get
   end
 
   expose(:columns) do

--- a/app/services/scheduling/stats.rb
+++ b/app/services/scheduling/stats.rb
@@ -1,0 +1,35 @@
+module Scheduling
+  class Stats
+    def initialize(repository, admin_mode)
+      @repository = repository
+      @admin_mode = admin_mode
+    end
+
+    def get
+      @stats ||= {
+        all: count_sql(repository.all),
+        juniors_and_interns: count_sql(repository.scheduled_juniors_and_interns),
+        to_rotate: count_sql(repository.to_rotate),
+        in_internals: count_sql(repository.in_internals),
+        with_rotations_in_progress: count_sql(repository.with_rotations_in_progress),
+        in_commercial_projects_with_due_date: count_sql(repository.in_commercial_projects_with_due_date),
+        booked: count_sql(repository.booked),
+        unavailable: count_sql(repository.unavailable),
+      }
+      @stats[:not_scheduled] ||= count_sql(repository.not_scheduled) if admin_mode
+      @stats
+    end
+
+    private
+
+    attr_reader :repository, :admin_mode
+
+    def count_sql(query)
+      ActiveRecord::Base
+        .connection
+        .execute("SELECT COUNT(*) FROM ( #{query.to_sql} ) AS res")
+        .entries[0]['count']
+        .to_i
+    end
+  end
+end

--- a/spec/services/scheduling/stats_spec.rb
+++ b/spec/services/scheduling/stats_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Scheduling::Stats do
+  let!(:intern) { create(:user, :intern) }
+  let!(:junior) { create(:user, :junior) }
+  let!(:interns_and_juniors) do
+    create(:membership, user: intern,  project: create(:project))
+    create(:membership, user: junior,  project: create(:project))
+  end
+  let!(:commercial_project_without_due_date) do
+    project = create(:project, :without_due_date, :commercial)
+    build(:scheduled_users_hash, project: project)
+  end
+  let!(:commercial_project_with_due_date) do
+    project = create(:project, :commercial)
+    build(:scheduled_users_hash, project: project)
+  end
+  let!(:internal_project) do
+    project = create(:project, :internal)
+    build(:scheduled_users_hash, project: project)
+  end
+  let!(:unavailable) do
+    project = UnavailableProjectBuilder.new.call
+    build(:scheduled_users_hash, project: project)
+  end
+  let!(:not_scheduled) do
+    create(:user, :developer)
+  end
+
+  let(:repository) { ScheduledUsersRepository.new }
+  let(:admin_mode) { true }
+
+  subject { described_class.new(repository, admin_mode) }
+
+  let(:expected_stats) do
+    {
+      all: 35,
+      juniors_and_interns: 2,
+      to_rotate: 2,
+      in_internals: 4,
+      with_rotations_in_progress: 6,
+      in_commercial_projects_with_due_date: 6,
+      booked: 6,
+      unavailable: 8,
+      not_scheduled: 1
+    }
+  end
+
+  it 'return proper numbers' do
+    stats = subject.get
+    aggregate_failures do
+      expected_stats.each do |k, v|
+        expect(stats.fetch(k)).to eq(v)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a separate service object In order to improve slightly performance of computing numbers of users in each category in scheduling.
Counting is performed with `ActiveRecord::Base.connection.execute` which does not bind fetched data to Ruby Objects.

**Changes:**
- add Scheduling::Stats and specs
- use it in SchedulingController
