### PR TITLE
People 138 update user skill rate content if exists

### DIFF
--- a/app/models/user_skill_rate/content.rb
+++ b/app/models/user_skill_rate/content.rb
@@ -1,11 +1,7 @@
 class UserSkillRate::Content < ActiveRecord::Base
   belongs_to :user_skill_rate
 
-  scope :today, -> do
-    where(
-      'created_at > ?', Time.zone.now.beginning_of_day
-    )
-  end
+  scope :today, -> { where('created_at > ?', Time.zone.now.beginning_of_day) }
 
   validates :rate, presence: true
   validates_with ::UserSkillRate::RateWithinRangeValidator

--- a/app/models/user_skill_rate/content.rb
+++ b/app/models/user_skill_rate/content.rb
@@ -1,6 +1,12 @@
 class UserSkillRate::Content < ActiveRecord::Base
   belongs_to :user_skill_rate
 
+  scope :today, -> do
+    where(
+      'created_at > ?', Time.zone.now.beginning_of_day
+    )
+  end
+
   validates :rate, presence: true
   validates_with ::UserSkillRate::RateWithinRangeValidator
 

--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -22,7 +22,6 @@ module Skills
 
       def create_or_update_user_skill_rate_content
         if user_skill_rate_content
-          binding.pry
           user_skill_rate_content.update_attributes(update_params)
         else
           user_skill_rate.contents.create(params)

--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -8,7 +8,7 @@ module Skills
 
       def call
         update_user_skill_rate
-        create_new_user_skill_rate_content
+        create_or_update_user_skill_rate_content
         user_skill_rate
       end
 
@@ -17,15 +17,30 @@ module Skills
       attr_reader :user_skill_rate_id, :params
 
       def update_user_skill_rate
-        user_skill_rate.update_attributes(params)
+        user_skill_rate.update_attributes(update_params)
       end
 
-      def create_new_user_skill_rate_content
-        user_skill_rate.contents.create(params)
+      def create_or_update_user_skill_rate_content
+        if user_skill_rate_content
+          binding.pry
+          user_skill_rate_content.update_attributes(update_params)
+        else
+          user_skill_rate.contents.create(params)
+        end
+      end
+
+      def user_skill_rate_content
+        @user_skill_rate_content ||= user_skill_rate.contents.where(
+          "created_at > ?", Time.zone.now.beginning_of_day
+        ).last
       end
 
       def user_skill_rate
         @user_skill_rate ||= ::UserSkillRate.find(user_skill_rate_id)
+      end
+
+      def update_params
+        @update_params ||= params.slice(:note, :rate, :favorite)
       end
     end
   end

--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -17,12 +17,12 @@ module Skills
       attr_reader :user_skill_rate_id, :params
 
       def update_user_skill_rate
-        user_skill_rate.update_attributes(update_params)
+        user_skill_rate.update(update_params)
       end
 
       def create_or_update_user_skill_rate_content
         if user_skill_rate_content
-          user_skill_rate_content.update_attributes(update_params)
+          user_skill_rate_content.update(update_params)
         else
           user_skill_rate.contents.create(params)
         end

--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -29,9 +29,7 @@ module Skills
       end
 
       def user_skill_rate_content
-        @user_skill_rate_content ||= user_skill_rate.contents.where(
-          "created_at > ?", Time.zone.now.beginning_of_day
-        ).last
+        @user_skill_rate_content ||= user_skill_rate.contents.today.last
       end
 
       def user_skill_rate

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -38,7 +38,7 @@ describe ::Skills::UserSkillRates::Update do
       let(:last_content) { user_skill_rate.contents.last }
 
       it 'creates new user_skill_rate_content' do
-        expect { subject.call }.to change { user_skill_rate.contents.count }
+        expect { subject.call }.to change { user_skill_rate.contents.count }.by(1)
       end
 
       it 'sets correct values on new content' do

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -9,7 +9,6 @@ describe ::Skills::UserSkillRates::Update do
   end
 
   describe '#call' do
-    let(:last_content) { user_skill_rate.contents.last }
     let(:user) { create(:user) }
     let(:user_skill_rate) do
       create(:user_skill_rate, note: 'abc', rate: 0, favorite: false, user: user)
@@ -36,6 +35,8 @@ describe ::Skills::UserSkillRates::Update do
     end
 
     context "when user_skill_rate_content doesn't exist today" do
+      let(:last_content) { user_skill_rate.contents.last }
+
       it 'creates new user_skill_rate_content' do
         expect { subject.call }.to change { user_skill_rate.contents.count }
       end

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -24,20 +24,20 @@ describe ::Skills::UserSkillRates::Update do
     end
 
     it 'updates note on user rate skill' do
-      expect{ subject.call }.to change{ user_skill_rate.reload.note }.from('abc').to('def')
+      expect { subject.call }.to change { user_skill_rate.reload.note }.from('abc').to('def')
     end
 
     it 'updates favorite on user rate skill' do
-      expect{ subject.call }.to change{ user_skill_rate.reload.rate }.from(0).to(1)
+      expect { subject.call }.to change { user_skill_rate.reload.rate }.from(0).to(1)
     end
 
     it 'updates favorite on user favorite skill' do
-      expect{ subject.call }.to change{ user_skill_rate.reload.favorite }.from(false).to(true)
+      expect { subject.call }.to change { user_skill_rate.reload.favorite }.from(false).to(true)
     end
 
     context "when user_skill_rate_content doesn't exist today" do
       it 'creates new user_skill_rate_content' do
-        expect{ subject.call }.to change{ user_skill_rate.contents.count }
+        expect { subject.call }.to change { user_skill_rate.contents.count }
       end
 
       it 'sets correct values on new content' do
@@ -53,13 +53,14 @@ describe ::Skills::UserSkillRates::Update do
 
     context 'when user_skill_rate_content exists today' do
       let!(:user_skill_rate_content) do
-        create(:user_skill_rate_content,
+        create(
+          :user_skill_rate_content,
           user_skill_rate_id: user_skill_rate.id
         )
       end
 
       it "doesn't create new user_skill_rate_content" do
-        expect{ subject.call }.to_not change{ user_skill_rate.contents.count }
+        expect { subject.call }.to_not change { user_skill_rate.contents.count }
       end
 
       it 'updates content' do

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -35,17 +35,43 @@ describe ::Skills::UserSkillRates::Update do
       expect{ subject.call }.to change{ user_skill_rate.reload.favorite }.from(false).to(true)
     end
 
-    it 'creates new user_skill_rate_content' do
-      expect{ subject.call }.to change{ user_skill_rate.contents.count }
+    context "when user_skill_rate_content doesn't exist today" do
+      it 'creates new user_skill_rate_content' do
+        expect{ subject.call }.to change{ user_skill_rate.contents.count }
+      end
+
+      it 'sets correct values on new content' do
+        subject.call
+        user_skill_rate.reload
+        aggregate_failures do
+          expect(last_content.favorite).to eq(user_skill_rate.favorite)
+          expect(last_content.note).to eq(user_skill_rate.note)
+          expect(last_content.rate).to eq(user_skill_rate.rate)
+        end
+      end
     end
 
-    it 'sets correct values on new content' do
-      subject.call
-      user_skill_rate.reload
-      aggregate_failures do
-        expect(last_content.favorite).to eq(user_skill_rate.favorite)
-        expect(last_content.note).to eq(user_skill_rate.note)
-        expect(last_content.rate).to eq(user_skill_rate.rate)
+    context 'when user_skill_rate_content exists today' do
+      let!(:user_skill_rate_content) do
+        create(:user_skill_rate_content,
+          user_skill_rate_id: user_skill_rate.id
+        )
+      end
+
+      it "doesn't create new user_skill_rate_content" do
+        expect{ subject.call }.to_not change{ user_skill_rate.contents.count }
+      end
+
+      it 'updates content' do
+        subject.call
+        user_skill_rate_content.reload
+        user_skill_rate.reload
+        aggregate_failures do
+          expect(user_skill_rate_content.favorite)
+            .to eq(user_skill_rate.favorite)
+          expect(user_skill_rate_content.note).to eq(user_skill_rate.note)
+          expect(user_skill_rate_content.rate).to eq(user_skill_rate.rate)
+        end
       end
     end
   end

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -41,14 +41,12 @@ describe ::Skills::UserSkillRates::Update do
         expect { subject.call }.to change { user_skill_rate.contents.count }.by(1)
       end
 
-      it 'sets correct values on new content' do
+      it 'sets correct values on new content', :aggregate_failures do
         subject.call
         user_skill_rate.reload
-        aggregate_failures do
-          expect(last_content.favorite).to eq(user_skill_rate.favorite)
-          expect(last_content.note).to eq(user_skill_rate.note)
-          expect(last_content.rate).to eq(user_skill_rate.rate)
-        end
+        expect(last_content.favorite).to eq(user_skill_rate.favorite)
+        expect(last_content.note).to eq(user_skill_rate.note)
+        expect(last_content.rate).to eq(user_skill_rate.rate)
       end
     end
 
@@ -64,16 +62,14 @@ describe ::Skills::UserSkillRates::Update do
         expect { subject.call }.to_not change { user_skill_rate.contents.count }
       end
 
-      it 'updates content' do
+      it 'updates content', :aggregate_failures do
         subject.call
         user_skill_rate_content.reload
         user_skill_rate.reload
-        aggregate_failures do
-          expect(user_skill_rate_content.favorite)
-            .to eq(user_skill_rate.favorite)
-          expect(user_skill_rate_content.note).to eq(user_skill_rate.note)
-          expect(user_skill_rate_content.rate).to eq(user_skill_rate.rate)
-        end
+        expect(user_skill_rate_content.favorite)
+          .to eq(user_skill_rate.favorite)
+        expect(user_skill_rate_content.note).to eq(user_skill_rate.note)
+        expect(user_skill_rate_content.rate).to eq(user_skill_rate.rate)
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-138

# Description
- user is able to edit his user_skill_rate multiple time during the day. We don't want to create new history each change during one day. Instead of that we find user_skill_rate_content from today and update it.

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

