### PR TITLE
Added uniqueness for skill scoped by user on user_skill_rate

### DIFF
--- a/app/models/user_skill_rate.rb
+++ b/app/models/user_skill_rate.rb
@@ -5,6 +5,7 @@ class UserSkillRate < ActiveRecord::Base
   has_many :contents, class_name: '::UserSkillRate::Content'
 
   validates :user, :skill, presence: true
+  validates :skill, uniqueness: { scope: :user }
 
   def content
     contents.order('user_skill_rate_contents.created_at asc').last

--- a/spec/models/user_skill_rate_spec.rb
+++ b/spec/models/user_skill_rate_spec.rb
@@ -7,8 +7,17 @@ describe UserSkillRate do
   end
 
   describe 'validations' do
-    it { is_expected.to  validate_presence_of :skill }
-    it { is_expected.to  validate_presence_of :user }
+    let(:user_skill_rate) { create(:user_skill_rate) }
+
+    it { is_expected.to validate_presence_of :skill }
+    it { is_expected.to validate_presence_of :user }
+
+    # there is a problem inside shoulda gem, check this issue on GH: https://github.com/thoughtbot/shoulda-matchers/issues/535
+    it 'enforces uniqueness' do
+      expect(
+        user_skill_rate
+      ).to validate_uniqueness_of(:skill).scoped_to(:user_id)
+    end
   end
 
   describe '#content' do


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-153

# Description
There should be only single user_skill_rate between specific user and skill. 
- Added uniqueness for skill scoped by user on user_skill_rate
