### PR TITLE
(Hopefully) Fix randomly failing specs

### DIFF
--- a/spec/factories/skill_category.rb
+++ b/spec/factories/skill_category.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :skill_category do
-    name { Faker::Name.name.gsub(' ', '') }
+    name { Faker::Name.name.delete(' ') }
   end
 end

--- a/spec/factories/skill_category.rb
+++ b/spec/factories/skill_category.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :skill_category do
-    name { Faker::Color.color_name.gsub(' ', '_') }
+    name { Faker::Name.name.gsub(' ', '') }
   end
 end


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-155

# Description
 - the *ActiveRecord::RecordInvalid: Validation failed: Name has already been taken* which we saw all over the place and thought it related to Skill, actually related to SkillCategory which was 
created each time we called **create(:skill)**. the SkillCategory model has a uniqueness validation for :name and the **Faker::Color.color_name** we used in it's factory didn't seem to be 'random enough' 