### PR TITLE
People 169 hot fix primary role

### DIFF
--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -45,6 +45,7 @@ class PositionsController < ApplicationController
     position = Position.find(params[:id])
     position.toggle!(:primary)
     if position.primary
+      current_user.update(primary_role: position.role)
       SendMailWithUserJob.perform_async(
         PositionMailer, :new_primary, position, current_user.id
       )

--- a/app/serializers/user_scheduling_serializer.rb
+++ b/app/serializers/user_scheduling_serializer.rb
@@ -9,7 +9,7 @@ class UserSchedulingSerializer < ActiveModel::Serializer
   end
 
   def primary_role
-    role = object.primary_roles[0]
+    role = object.primary_role
     { name: role.try(:name), id: role.try(:id) }
   end
 


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-169

# Description
- we had a problem that user had displayed incorrect primary_role. I have fixed it in serializer. It required to add logic for updating primary_role on user. Also I had to update all users on production without primary_role to have one. 

`user.primary_role = user.primary_roles[0]`

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

