### PR TITLE
People 165 fix issues with skills rating

### DIFF
--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -9,6 +9,7 @@ module Skills
       def call
         update_user_skill_rate
         create_or_update_user_skill_rate_content
+        remove_last_content if last_two_contents_are_equal?
         user_skill_rate
       end
 
@@ -38,6 +39,20 @@ module Skills
 
       def update_params
         @update_params ||= params.slice(:note, :rate, :favorite)
+      end
+
+      def last_two_contents_are_equal?
+        contents = user_skill_rate.reload.contents.last(2)
+        return false if contents.length < 2
+        content_attributes(contents[0]) == content_attributes(contents[1])
+      end
+
+      def content_attributes(content)
+         content.attributes.slice('rate', 'note', 'favorite')
+      end
+
+      def remove_last_content
+        user_skill_rate.contents.last.destroy
       end
     end
   end

--- a/app/services/skills/user_skill_rates/update.rb
+++ b/app/services/skills/user_skill_rates/update.rb
@@ -48,7 +48,7 @@ module Skills
       end
 
       def content_attributes(content)
-         content.attributes.slice('rate', 'note', 'favorite')
+        content.attributes.slice('rate', 'note', 'favorite')
       end
 
       def remove_last_content

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -72,5 +72,50 @@ describe ::Skills::UserSkillRates::Update do
         expect(user_skill_rate_content.rate).to eq(user_skill_rate.rate)
       end
     end
+
+    context 'when two last user_skill_rate_contents are equal' do
+      let(:params) do
+        {
+          id: user_skill_rate.id,
+          note: 'def',
+          rate: 1,
+          favorite: true
+        }
+      end
+
+      before do
+        Timecop.freeze(DateTime.now - 3.days) do
+          create(
+            :user_skill_rate_content,
+            user_skill_rate_id: user_skill_rate.id,
+            note: 'def',
+            rate: 1,
+            favorite: true
+          )
+        end
+      end
+
+      context 'when add new user_skill_rate_content' do
+        it "doesn't add new user_skill_rate_content" do
+          expect { subject.call }.to_not change { user_skill_rate.contents.count }
+        end
+      end
+
+      context 'when update last user_skill_rate_content' do
+        let!(:user_skill_rate_content) do
+          create(
+            :user_skill_rate_content,
+            user_skill_rate_id: user_skill_rate.id,
+            note: 'def',
+            rate: 1,
+            favorite: true
+          )
+        end
+
+        it "removes last user_skill_rate_content" do
+          expect { subject.call }.to change { user_skill_rate.contents.count }.by(-1)
+        end
+      end
+    end
   end
 end

--- a/spec/services/skills/user_skill_rates/update_spec.rb
+++ b/spec/services/skills/user_skill_rates/update_spec.rb
@@ -112,7 +112,7 @@ describe ::Skills::UserSkillRates::Update do
           )
         end
 
-        it "removes last user_skill_rate_content" do
+        it 'removes last user_skill_rate_content' do
           expect { subject.call }.to change { user_skill_rate.contents.count }.by(-1)
         end
       end


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-165

# Description
- we have a problem with skill history. When someone changed his skill, and after that changed it again to the same value as it was before first change, then we don't want to store it in database as a change. 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

