### PR TITLE
People 177 fix navbar for skills

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -42,13 +42,6 @@
                 %li{ class: menu_class('roles') }= link_to "Roles", roles_path
                 %li{ class: menu_class('abilities') }= link_to "Abilities", abilities_path
                 %li= link_to "Reports", AppConfig.reports_url, target: '_blank'
-          - elsif current_user.talent? || current_user.leader?
-            %li.dropdown
-              %a.dropdown-toggle{ href: "#", :'data-toggle' => "dropdown" }
-                Other
-                %b.caret
-              %ul.dropdown-menu
-                %li{ class: menu_class('skills') }= link_to "Skills", skills_path
       - if signed_in?
         %ul.nav.navbar-nav.navbar-right.user-profile
           %li.dropdown

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -23,15 +23,16 @@
             %ul.dropdown-menu
               %li{ class: menu_class('skills') }= link_to 'My skills', user_skill_rates_path
               %li{ class: menu_class('skills') }= link_to 'My skills history', skills_history_user_path(current_user)
-              - if current_user.leader?
+              - if policy(current_user).skill_access?
                 %li.divider{ role: 'separator' }
                 %li.dropdown-header Admin
                 %li{ class: menu_class('skills') }= link_to "All skills", skills_path
                 %li{ class: menu_class('draft_skills') }= link_to "All requested changes", draft_skills_path
-                %li.divider{ role: 'separator' }
-                %li.dropdown-header My team members history
-                - team_members.each do |member|
-                  %li{ class: menu_class('skills') }= link_to member.name, skills_history_user_path(member)
+                - if current_user.leader?
+                  %li.divider{ role: 'separator' }
+                  %li.dropdown-header My team members history
+                  - team_members.each do |member|
+                    %li{ class: menu_class('skills') }= link_to member.name, skills_history_user_path(member)
 
           - if current_user.admin?
             %li.dropdown


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-177

# Description
- allow admin, talent and leader to see navigation links for skills and draft_skills
- removed duplication from other section for skills navigation link 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

