### PR TITLE
set primary_role when new primary position is set

### DIFF
--- a/app/services/save_position.rb
+++ b/app/services/save_position.rb
@@ -6,15 +6,19 @@ class SavePosition
   end
 
   def call
-    position.save && update_user_commitment
+    position.save && set_primary_role && update_user_commitment
   end
 
   private
 
+  def set_primary_role
+    return true unless position.primary
+    position.user.update(primary_role: position.role)
+  end
+
   def update_user_commitment
     user = CommitmentSetter.new(position.user,
       position.role.name.to_sym).call
-
     user.save
   end
 end

--- a/spec/services/save_position_spec.rb
+++ b/spec/services/save_position_spec.rb
@@ -6,7 +6,7 @@ describe SavePosition do
 
   subject { described_class.new(position).call }
 
-  context 'valid position' do
+  context 'when position is valid' do
     it 'creates a new position' do
       expect { subject }.to change(Position, :count).by 1
     end
@@ -14,9 +14,17 @@ describe SavePosition do
     it 'returns true' do
       expect(subject).to be true
     end
+
+    context 'when position is primary' do
+      let(:position) { build(:position, :primary, user: user) }
+
+      it 'sets new primary_role for user' do
+        expect { subject }.to change { user.primary_role }.to(position.role)
+      end
+    end
   end
 
-  context 'invalid position' do
+  context 'when position is invalid' do
     before { position.user = nil }
 
     it 'does not create a new position' do


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-186

# Description
- update main primary_role when new primary position is created 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

