### PR TITLE
display only active users

### DIFF
--- a/app/repositories/team_users_repository.rb
+++ b/app/repositories/team_users_repository.rb
@@ -14,6 +14,6 @@ class TeamUsersRepository
   end
 
   def subordinates
-    team.users.where.not(id: leader.id)
+    team.users.active.where.not(id: leader.id)
   end
 end

--- a/spec/repositories/team_users_repository_spec.rb
+++ b/spec/repositories/team_users_repository_spec.rb
@@ -24,5 +24,17 @@ describe TeamUsersRepository do
     it 'retrieves all users except leader' do
       expect(subject.subordinates).not_to include user
     end
+
+    context 'with archived users' do
+      let(:archived_user) { create(:user, archived: true) }
+
+      before do
+        team.users << archived_user
+      end
+
+      it 'retrieves all users except archived team members' do
+        expect(subject.subordinates).not_to include archived_user
+      end
+    end
   end
 end


### PR DESCRIPTION
Team leader should only see active users.

### Before merge checklist
- [x] CircleCI is passing
- [x] Proper labels are set

