### PR TITLE
Sicne user_skill_rates are displayed in name order, we have to specif…

### DIFF
--- a/spec/features/user_skill_rates_spec.rb
+++ b/spec/features/user_skill_rates_spec.rb
@@ -6,9 +6,33 @@ describe 'User skill rates page', js: true do
   let(:skill_category_1) { create :skill_category, name: 'backend' }
   let(:skill_category_2) { create :skill_category, name: 'ios' }
 
-  let(:skills_range) { create_list :skill, 2, :with_range_rate_type, skill_category: skill_category_1 }
-  let(:skills_boolean) { create_list :skill, 2, :with_boolean_rate_type, skill_category: skill_category_2 }
+  let(:skills_range) { [range_skill_1, range_skill_2] }
+  let!(:range_skill_1) do
+    create(:skill, :with_range_rate_type,
+      skill_category: skill_category_1,
+      name: 'a skill'
+    )
+  end
+  let!(:range_skill_2) do
+    create(:skill, :with_range_rate_type,
+      skill_category: skill_category_1,
+      name: 'b skill'
+    )
+  end
 
+  let!(:boolean_skill_1) do
+    create(:skill, :with_boolean_rate_type,
+      skill_category: skill_category_2,
+      name: 'c skill'
+    )
+  end
+  let!(:boolean_skill_2) do
+    create(:skill, :with_boolean_rate_type,
+      skill_category: skill_category_2,
+      name: 'd skill'
+    )
+  end
+  let(:skills_boolean) { [boolean_skill_1, boolean_skill_2] }
   let!(:developer) { create(:user, :developer, skills: skills_range + skills_boolean) }
 
   context 'when user does not have any marked skills' do

--- a/spec/support/shared_examples/user_skill_rates_controller_shared.rb
+++ b/spec/support/shared_examples/user_skill_rates_controller_shared.rb
@@ -4,7 +4,9 @@ shared_examples 'returns correct hash and response is 200' do
   it 'returns correct hash', :aggregate_failures do
     skill_rates = json_response['user_skill_rates']
     expect(skill_rates).to be_a(Array)
-    expect(skill_rates).to eq(expected_array)
+    expected_array.map do |expected_hash|
+      expect(skill_rates).to include(expected_hash)
+    end
   end
 end
 


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-192

# Description
Since user_skill_rates are displayed in name order, we have to specify order of creating user skill rates and names for them

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

