### PR TITLE
new config for circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,16 @@ deployment:
 dependencies:
   pre:
     - cp config/sec_config.yml.sample config/sec_config.yml
+    - sudo pip install mozdownload mozinstall
+    - mozdownload --version 51.0.1 --destination firefox.tar.bz2
+    - mozinstall firefox.tar.bz2
+    - wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
+    - tar -xvzf geckodriver*
+    - chmod +x geckodriver
+    - export PATH=$PATH:/home/ubuntu/people/geckodriver
+    - . ~/.bashrc
   post:
-    - sudo apt-get update && sudo apt-get install libpango1.0-0 && sudo apt-get install firefox
+    - sudo apt-get update && sudo apt-get install libpango1.0-0
     - npm install webpack -g
     - webpack
   cache_directories:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,11 @@ CarrierWave.configure do |config|
   config.enable_processing = false
 end
 
+# we have problems with geckodriver and newest version of firefox(52) new configuration is added to circle.yml in dependencies: pre: state
+if ENV['CI']
+  Selenium::WebDriver::Firefox::Binary.path = '/home/ubuntu/people/firefox/firefox'
+end
+
 Capybara.default_max_wait_time = 5
 
 Capybara.register_driver :selenium do |app|


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/PEOPLE-199

# Description
- Selenium::WebDriver::Error::WebDriverError: 
Unable to find Mozilla geckodriver. Please download the server from https://github.com/mozilla/geckodriver/releases and place it somewhere on your PATH. More info at https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver.
- there was also a problem with new version of firefox. We had to downgrade it. 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

