### PR TITLE
Show other documents field in project info

### DIFF
--- a/app/views/project_info/show.html.haml
+++ b/app/views/project_info/show.html.haml
@@ -125,6 +125,12 @@
         %p Functional notes:
       .col-sm-6
         %p= api_link(project_info[:functional_notes])
+  .row
+    .col-sm-12
+      .col-sm-2.project-label
+        %p Other documents:
+      .col-sm-10
+        %p= project_info[:other_documents]
   %hr
   .row
     %p Tools


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/SALE-180

# Description
- show Other documents field from Salesforce in Project Info section

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

