### PR TITLE
Allow get acrtions from ajax to api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'httparty'
 gem 'active_model_serializers'
 gem 'react_webpack_rails'
 gem 'rake-progressbar'
+gem 'rack-cors', require: 'rack/cors'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,7 @@ GEM
     rabl (0.11.8)
       activesupport (>= 2.3.14)
     rack (1.6.4)
+    rack-cors (0.4.1)
     rack-mini-profiler (0.9.8)
       rack (>= 1.1.3)
     rack-test (0.6.3)
@@ -700,6 +701,7 @@ DEPENDENCIES
   pundit
   quiet_assets
   rabl
+  rack-cors
   rack-mini-profiler
   rack_session_access
   rails (~> 4.2)
@@ -730,4 +732,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.13.6
+   1.14.5

--- a/app/serializers/api/v3/memberships_history_serializer.rb
+++ b/app/serializers/api/v3/memberships_history_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V3
     class MembershipsHistorySerializer < ActiveModel::Serializer
-      attributes :project_name, :user_name, :user_email, :user_role
+      attributes :project_name, :user_name, :user_email, :user_role, :id
 
       def project_name
         object.project.name

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,13 @@ module Hrguru
       g.orm :active_record
     end
 
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get]
+      end
+    end
+
     config.i18n.default_locale = :en
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml')]
     config.assets.initialize_on_precompile = true # required by i18n-js

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,12 @@ module Hrguru
     config.middleware.insert_before 0, "Rack::Cors" do
       allow do
         origins '*'
-        resource '*', headers: :any, methods: [:get]
+        resource(
+          '*',
+          headers: :any,
+          methods: [:get],
+          if: proc { |env| env['PATH_INFO'].start_with? "/api" }
+        )
       end
     end
 

--- a/spec/controllers/api/v3/memberships_controller_spec.rb
+++ b/spec/controllers/api/v3/memberships_controller_spec.rb
@@ -48,7 +48,7 @@ describe Api::V3::MembershipsController do
     it 'returns correct values' do
       expect(json_response).to be_kind_of(Array)
       expect(json_response.first.keys).to contain_exactly(
-        'project_name', 'user_name', 'user_email', 'user_role'
+        'id', 'project_name', 'user_name', 'user_email', 'user_role'
       )
     end
   end

--- a/spec/lib/rack_cors_spec.rb
+++ b/spec/lib/rack_cors_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+RSpec.describe "Request support for CORS headers", type: :request do
+  it 'returns the response CORS headers' do
+    get '/api/v3/memberships', nil, 'HTTP_ORIGIN' => '*'
+
+    expect(response.headers['Access-Control-Allow-Origin']).to eq('*')
+    expect(response.headers['Access-Control-Allow-Methods']).to eq('GET')
+  end
+end

--- a/spec/serializers/api/v3/memberships_history_serializer_spec.rb
+++ b/spec/serializers/api/v3/memberships_history_serializer_spec.rb
@@ -12,4 +12,5 @@ describe Api::V3::MembershipsHistorySerializer do
   it { expect(subject[:user_role]).to eq(role.name) }
   it { expect(subject[:user_name]).to eq(user_full_name) }
   it { expect(subject[:user_email]).to eq(user.email) }
+  it { expect(subject[:id]).to eq(object.id) }
 end


### PR DESCRIPTION
# Description
- added rack-cors gem and configure it to allow GET request to API. 
- added memberships id to membership history serializer 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

