### PR TITLE
Fixed overlapped scope in membership

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -29,14 +29,8 @@ class Membership < ActiveRecord::Base
   scope :without_user, -> (user) { where('user_id != ?', user.id) }
   scope :overlaps, -> (starts_at, ends_at) do
     where(
-      '(
-        (starts_at, ends_at) overlaps (:starts_at, :ends_at)
-        OR
-        (starts_at < :starts_at AND ends_at is NULL)
-        OR
-        (starts_at > :starts_at AND starts_at < ends_at AND ends_at is NULL)
-      )',
-      starts_at: starts_at, ends_at: ends_at
+      '(starts_at, COALESCE(ends_at, :now)) overlaps (:starts_at, :ends_at)',
+      starts_at: membership.starts_at, ends_at: membership.ends_at, now: Time.zone.now
     )
   end
   scope :unfinished, -> do

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -32,7 +32,7 @@ class Membership < ActiveRecord::Base
   scope :overlaps, -> (starts_at, ends_at) do
     where(
       '(starts_at, COALESCE(ends_at, :now)) overlaps (:starts_at, :ends_at)',
-      starts_at: membership.starts_at, ends_at: membership.ends_at, now: Time.zone.now
+      starts_at: starts_at, ends_at: ends_at, now: Time.zone.now
     )
   end
   scope :unfinished, -> do

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -23,10 +23,12 @@ class Membership < ActiveRecord::Base
   scope :non_archived, -> { where(project_archived: false) }
   scope :archived, -> { where(project_archived: true) }
   scope :active, -> { non_archived.non_booked.non_potential }
+  scope :only_active_user, -> { joins(:user).where(users: { archived: false } ) }
   scope :potential, -> { where(project_potential: true) }
   scope :with_role, -> (role) { where(role: role) }
   scope :with_user, -> (user) { where(user: user) }
   scope :without_user, -> (user) { where('user_id != ?', user.id) }
+  scope :with_project, -> (project) { where(project: project) }
   scope :overlaps, -> (starts_at, ends_at) do
     where(
       '(starts_at, COALESCE(ends_at, :now)) overlaps (:starts_at, :ends_at)',

--- a/app/queries/api/v3/memberships_query.rb
+++ b/app/queries/api/v3/memberships_query.rb
@@ -6,14 +6,21 @@ module Api
       def all_overlapped(filter_params)
         @filter_params = filter_params
         all_overlapped = all_user_memberhips.map do |membership|
-          Membership.without_user(user).where(
-            project_id: membership.project_id
-          ).overlaps(membership.starts_at, membership.ends_at)
+          overlapped_with(membership)
         end
         all_overlapped.flatten
       end
 
       private
+
+      def overlapped_with(membership)
+        ends_at = membership.ends_at || Time.zone.now + 1.month
+        Membership.only_active_user.without_user(
+          user
+        ).with_project(membership.project).overlaps(
+          membership.starts_at, ends_at
+        )
+      end
 
       def all_user_memberhips
         @all_user_memberhips ||= Membership.with_user(user).overlaps(

--- a/app/queries/api/v3/memberships_query.rb
+++ b/app/queries/api/v3/memberships_query.rb
@@ -14,7 +14,8 @@ module Api
       private
 
       def overlapped_with(membership)
-        ends_at = membership.ends_at || Time.zone.now + 1.month
+        date_in_future = Time.zone.now + 1.month
+        ends_at = membership.ends_at || date_in_future
         Membership.only_active_user.without_user(
           user
         ).with_project(membership.project).overlaps(


### PR DESCRIPTION
# Description
- memberships should return only not archived people. 
- fixed issue with overlapped memberships. There was a problem when ends_at equals nil 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

