### PR TITLE
return only acrtive team members

### DIFF
--- a/app/controllers/api/v3/team_members_controller.rb
+++ b/app/controllers/api/v3/team_members_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V3
     class TeamMembersController < Api::ApiController
-      expose(:team_members) { team.users }
+      expose(:team_members) { team.users.active }
       expose(:team) do
         Team.where(name: team_members_params['team_name']).first
       end

--- a/spec/controllers/api/v3/team_members_controller_spec.rb
+++ b/spec/controllers/api/v3/team_members_controller_spec.rb
@@ -8,12 +8,12 @@ describe Api::V3::TeamMembersController do
       create(
         :team,
         name: 'alpha',
-        users: [team_member_1, team_member_2]
+        users: [team_member_1, team_member_2, team_member_3]
       )
     end
     let(:team_member_1) { create(:user) }
     let(:team_member_2) { create(:user) }
-    let(:team_member_2) { create(:user, :archived) }
+    let(:team_member_3) { create(:user, :archived) }
 
     let(:token) { AppConfig.api_token }
     let(:params) do

--- a/spec/controllers/api/v3/team_members_controller_spec.rb
+++ b/spec/controllers/api/v3/team_members_controller_spec.rb
@@ -13,6 +13,7 @@ describe Api::V3::TeamMembersController do
     end
     let(:team_member_1) { create(:user) }
     let(:team_member_2) { create(:user) }
+    let(:team_member_2) { create(:user, :archived) }
 
     let(:token) { AppConfig.api_token }
     let(:params) do


### PR DESCRIPTION
# Description
- Modified API to return only active team members. 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

