### PR TITLE
set api_token and email in headers instead of params

### DIFF
--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -10,8 +10,8 @@ module Api
       end
 
       def user_authenticated?
-        email = request.headers["email"]
-        api_token = request.headers["api_token"]
+        email = request.headers["X-Email"]
+        api_token = request.headers["X-Api-Token"]
         return false if email.blank? || api_token.blank?
         User.where(email: email, api_token: api_token).active.exists?
       end

--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -10,8 +10,8 @@ module Api
       end
 
       def user_authenticated?
-        email = params[:email]
-        api_token = params[:api_token]
+        email = request.headers["email"]
+        api_token = request.headers["api_token"]
         return false if email.blank? || api_token.blank?
         User.where(email: email, api_token: api_token).active.exists?
       end

--- a/spec/controllers/api/v3/base_controller_spec.rb
+++ b/spec/controllers/api/v3/base_controller_spec.rb
@@ -39,9 +39,12 @@ describe Api::V3::BaseController do
       end
 
       context 'when current_user does not exist' do
-        before { get :index, params }
+        before do
+          request.headers["email"] = email
+          request.headers["api_token"] = api_token
+          get :index
+        end
         let(:user) { create(:user) }
-        let(:params) { { api_token: api_token, email: email } }
         let(:api_token) { user.api_token }
         let(:email) { user.email }
 

--- a/spec/controllers/api/v3/base_controller_spec.rb
+++ b/spec/controllers/api/v3/base_controller_spec.rb
@@ -40,8 +40,8 @@ describe Api::V3::BaseController do
 
       context 'when current_user does not exist' do
         before do
-          request.headers["email"] = email
-          request.headers["api_token"] = api_token
+          request.headers["X-Email"] = email
+          request.headers["X-Api-Token"] = api_token
           get :index
         end
         let(:user) { create(:user) }


### PR DESCRIPTION
# Description
We want to pass authenticate information in header instead of params 

### Before merge checklist
- [ ] CircleCI is passing
- [ ] Proper labels are set

