### PR TITLE
[RD-369] Fix problem with too many coworkers

### DIFF
--- a/app/queries/api/v3/memberships_query.rb
+++ b/app/queries/api/v3/memberships_query.rb
@@ -14,12 +14,12 @@ module Api
       private
 
       def overlapped_with(membership)
-        date_in_future = Time.zone.now + 1.month
-        ends_at = membership.ends_at || date_in_future
+        starts_at = filter_params[:f2f_date]
+        ends_at = membership.ends_at || 1.month.from_now
         Membership.only_active_user.without_user(
           user
         ).with_project(membership.project).overlaps(
-          membership.starts_at, ends_at
+          starts_at, ends_at
         )
       end
 

--- a/spec/queries/api/v3/memberships_query_spec.rb
+++ b/spec/queries/api/v3/memberships_query_spec.rb
@@ -44,7 +44,7 @@ describe Api::V3::MembershipsQuery do
   describe '#all_overlapped' do
     context 'when worked in the same project' do
       context 'when worked in the same time' do
-        it 'returns correct memberships' do
+        it 'returns correct memberships', :aggregate_failures do
           expect(subject).to_not include(membership_1)
           expect(subject).to include(membership_2)
           expect(subject).to include(membership_3)
@@ -63,7 +63,7 @@ describe Api::V3::MembershipsQuery do
             )
           end
 
-          it 'returns correct membership' do
+          it 'returns correct membership', :aggregate_failures do
             expect(subject).to_not include(membership_1)
             expect(subject).to include(membership_2)
             expect(subject).to_not include(membership_3)
@@ -81,7 +81,7 @@ describe Api::V3::MembershipsQuery do
             )
           end
 
-          it 'returns correct membership' do
+          it 'returns correct membership', :aggregate_failures do
             expect(subject).to_not include(membership_1)
             expect(subject).to include(membership_2)
             expect(subject).to_not include(membership_3)
@@ -102,7 +102,7 @@ describe Api::V3::MembershipsQuery do
         )
       end
 
-      it 'returns correct membership' do
+      it 'returns correct membership', :aggregate_failures do
         expect(subject).to_not include(membership_1)
         expect(subject).to include(membership_2)
         expect(subject).to_not include(membership_3)

--- a/spec/queries/api/v3/memberships_query_spec.rb
+++ b/spec/queries/api/v3/memberships_query_spec.rb
@@ -52,7 +52,7 @@ describe Api::V3::MembershipsQuery do
       end
 
       context 'when didin\'t work in the same time' do
-        context 'when he worked before requested user' do
+        context 'when he had worked before the requested user worked' do
           let!(:membership_3) do
             create(
               :membership,
@@ -70,7 +70,7 @@ describe Api::V3::MembershipsQuery do
           end
         end
 
-        context 'when he worked when requested user had left the project' do
+        context 'when he worked after the requested user had left the project' do
           let!(:membership_3) do
             create(
               :membership,


### PR DESCRIPTION
# Ticket
https://netguru.atlassian.net/browse/RD-369

# Description
It fixes the problem with too many coworkers being sent by the app's API. After changes, it selects only users that have worked with a person after his or her f2f, not users that he or she was working with from the beginning of the project membership.
